### PR TITLE
Feat: implement authentication flow with biometrics

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -5,17 +5,20 @@ import { colors } from '../theme/colors';
 export interface InputProps extends TextInputProps {
   label?: string;
   containerStyle?: StyleProp<ViewStyle>;
+  error?: string;
 }
 
 export const Input: React.FC<InputProps> = ({
   label,
   containerStyle,
+  error,
   onFocus,
   onBlur,
   secureTextEntry,
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false);
+  const hasError = Boolean(error);
 
   const handleFocus: TextInputProps['onFocus'] = event => {
     setIsFocused(true);
@@ -33,13 +36,21 @@ export const Input: React.FC<InputProps> = ({
       <TextInput
         placeholderTextColor={colors.textSecondary}
         selectionColor={colors.accent}
-        style={[styles.input, isFocused && styles.focusedInput, secureTextEntry && styles.secureFont]}
+        style={[
+          styles.input,
+          isFocused && styles.focusedInput,
+          secureTextEntry && styles.secureFont,
+          hasError && styles.errorInput,
+        ]}
         onFocus={handleFocus}
         onBlur={handleBlur}
         secureTextEntry={secureTextEntry}
         {...rest}
       />
-      <View style={[styles.underline, isFocused && styles.focusedUnderline]} />
+      <View
+        style={[styles.underline, isFocused && styles.focusedUnderline, hasError && styles.errorUnderline]}
+      />
+      {hasError ? <Text style={styles.errorText}>{error}</Text> : null}
     </View>
   );
 };
@@ -76,6 +87,18 @@ const styles = StyleSheet.create({
   },
   focusedUnderline: {
     backgroundColor: colors.accent,
+  },
+  errorInput: {
+    color: colors.textPrimary,
+  },
+  errorUnderline: {
+    backgroundColor: colors.error,
+  },
+  errorText: {
+    color: colors.error,
+    marginTop: 6,
+    fontSize: 12,
+    fontWeight: '500',
   },
 });
 

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,24 +1,260 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import * as LocalAuthentication from 'expo-local-authentication';
+import { Button } from '../components/Button';
+import { Input } from '../components/Input';
+import { useAuth } from '../contexts/AuthContext';
+import { colors } from '../theme/colors';
 import { layout, typography } from '../theme/styles';
+import { AuthStackParamList, RootStackParamList } from '../types/navigation';
 
-const LoginScreen: React.FC = () => (
-  <SafeAreaView style={[layout.screen, styles.container]}>
-    <Text style={styles.title}>Welcome back</Text>
-    <Text style={styles.subtitle}>Login flow coming soon.</Text>
-  </SafeAreaView>
-);
+type LoginScreenNavigation = NativeStackNavigationProp<AuthStackParamList, 'Login'>;
+
+type LoginErrors = Partial<Record<'email' | 'password', string>>;
+
+const showErrorToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.LONG);
+  } else {
+    Alert.alert('Login error', message);
+  }
+};
+
+const getBiometricLabel = (types: LocalAuthentication.AuthenticationType[]): string => {
+  if (types.includes(LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION)) {
+    return 'Face ID';
+  }
+
+  if (types.includes(LocalAuthentication.AuthenticationType.FINGERPRINT)) {
+    return 'Touch ID';
+  }
+
+  if (types.includes(LocalAuthentication.AuthenticationType.IRIS)) {
+    return 'Iris Scan';
+  }
+
+  return 'Biometrics';
+};
+
+const LoginScreen: React.FC = () => {
+  const navigation = useNavigation<LoginScreenNavigation>();
+  const rootNavigation = navigation.getParent<NativeStackNavigationProp<RootStackParamList>>();
+  const { login, biometricLogin } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState<LoginErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [biometricAvailable, setBiometricAvailable] = useState(false);
+  const [biometricLabel, setBiometricLabel] = useState('Biometrics');
+  const [biometricSubmitting, setBiometricSubmitting] = useState(false);
+
+  useEffect(() => {
+    const checkBiometrics = async () => {
+      try {
+        const hasHardware = await LocalAuthentication.hasHardwareAsync();
+        const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+
+        if (!hasHardware || !isEnrolled) {
+          setBiometricAvailable(false);
+          return;
+        }
+
+        const supportedTypes = await LocalAuthentication.supportedAuthenticationTypesAsync();
+        setBiometricLabel(getBiometricLabel(supportedTypes));
+        setBiometricAvailable(true);
+      } catch (error) {
+        console.warn('Unable to query biometric hardware', error);
+        setBiometricAvailable(false);
+      }
+    };
+
+    void checkBiometrics();
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const nextErrors: LoginErrors = {};
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+      nextErrors.email = 'Enter a valid email address.';
+    }
+
+    if (!password) {
+      nextErrors.password = 'Password is required.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [email, password]);
+
+  const handleLogin = useCallback(async () => {
+    if (submitting) {
+      return;
+    }
+
+    const isValid = validate();
+    if (!isValid) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await login(email.trim(), password);
+      rootNavigation?.navigate('Main');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to log you in.';
+      showErrorToast(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [submitting, validate, login, email, password, rootNavigation]);
+
+  const handleBiometricLogin = useCallback(async () => {
+    if (biometricSubmitting) {
+      return;
+    }
+
+    setBiometricSubmitting(true);
+
+    try {
+      await biometricLogin();
+      rootNavigation?.navigate('Main');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to log you in with biometrics.';
+      showErrorToast(message);
+    } finally {
+      setBiometricSubmitting(false);
+    }
+  }, [biometricSubmitting, biometricLogin, rootNavigation]);
+
+  const handleNavigateToSignup = useCallback(() => {
+    navigation.navigate('Signup');
+  }, [navigation]);
+
+  const biometricButtonLabel = useMemo(
+    () => `Login with ${biometricLabel}`,
+    [biometricLabel]
+  );
+
+  return (
+    <SafeAreaView style={[layout.screen, styles.container]}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.keyboardAvoidingView}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>Welcome back</Text>
+          <Text style={styles.subtitle}>Log in to manage your HASH wallet.</Text>
+
+          <View style={styles.form}>
+            <Input
+              label="Email"
+              placeholder="you@example.com"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              textContentType="emailAddress"
+              value={email}
+              onChangeText={value => {
+                setEmail(value);
+                if (errors.email) {
+                  setErrors(prev => ({ ...prev, email: undefined }));
+                }
+              }}
+              error={errors.email}
+            />
+
+            <Input
+              label="Password"
+              placeholder="Enter password"
+              secureTextEntry
+              textContentType="password"
+              value={password}
+              onChangeText={value => {
+                setPassword(value);
+                if (errors.password) {
+                  setErrors(prev => ({ ...prev, password: undefined }));
+                }
+              }}
+              error={errors.password}
+            />
+
+            <Button label="Login" onPress={handleLogin} loading={submitting} fullWidth />
+
+            {biometricAvailable ? (
+              <Button
+                label={biometricButtonLabel}
+                onPress={handleBiometricLogin}
+                loading={biometricSubmitting}
+                fullWidth
+                style={styles.biometricButton}
+              />
+            ) : null}
+          </View>
+
+          <Text style={styles.footerText}>
+            Don’t have an account?{' '}
+            <Text style={styles.footerLink} onPress={handleNavigateToSignup}>
+              Sign up
+            </Text>
+          </Text>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
+    backgroundColor: colors.background,
+    paddingHorizontal: 0,
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
     paddingTop: 48,
+    paddingBottom: 32,
   },
   title: {
     ...typography.heading,
-    marginBottom: 12,
+    marginBottom: 8,
   },
   subtitle: {
     ...typography.body,
+    color: colors.textSecondary,
+    marginBottom: 32,
+  },
+  form: {
+    marginBottom: 32,
+  },
+  footerText: {
+    ...typography.body,
+    color: colors.textSecondary,
+    textAlign: 'center',
+  },
+  footerLink: {
+    color: colors.accent,
+    fontWeight: '700',
+  },
+  biometricButton: {
+    marginTop: 8,
   },
 });
 

--- a/screens/SignupScreen.tsx
+++ b/screens/SignupScreen.tsx
@@ -1,24 +1,222 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Button } from '../components/Button';
+import { Input } from '../components/Input';
+import { useAuth } from '../contexts/AuthContext';
+import { colors } from '../theme/colors';
 import { layout, typography } from '../theme/styles';
+import { AuthStackParamList, RootStackParamList } from '../types/navigation';
 
-const SignupScreen: React.FC = () => (
-  <SafeAreaView style={[layout.screen, styles.container]}>
-    <Text style={styles.title}>Create your account</Text>
-    <Text style={styles.subtitle}>Signup flow coming soon.</Text>
-  </SafeAreaView>
-);
+const MIN_PASSWORD_LENGTH = 8;
+const PASSWORD_NUMBER_REGEX = /\d/;
+
+type SignupScreenNavigation = NativeStackNavigationProp<AuthStackParamList, 'Signup'>;
+
+interface SignupErrors {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+const showErrorToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.LONG);
+  } else {
+    Alert.alert('Signup error', message);
+  }
+};
+
+const SignupScreen: React.FC = () => {
+  const navigation = useNavigation<SignupScreenNavigation>();
+  const rootNavigation = navigation.getParent<NativeStackNavigationProp<RootStackParamList>>();
+  const { signup } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errors, setErrors] = useState<SignupErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const validate = useCallback((): boolean => {
+    const nextErrors: SignupErrors = {};
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+      nextErrors.email = 'Enter a valid email address.';
+    }
+
+    if (!password || password.length < MIN_PASSWORD_LENGTH) {
+      nextErrors.password = 'Password must be at least 8 characters.';
+    } else if (!PASSWORD_NUMBER_REGEX.test(password)) {
+      nextErrors.password = 'Password must include at least one number.';
+    }
+
+    if (!confirmPassword) {
+      nextErrors.confirmPassword = 'Please confirm your password.';
+    } else if (password !== confirmPassword) {
+      nextErrors.confirmPassword = 'Passwords do not match.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [email, password, confirmPassword]);
+
+  const helperText = useMemo(() => 'Password must be at least 8 characters and contain a number.', []);
+
+  const handleSignup = useCallback(async () => {
+    if (submitting) {
+      return;
+    }
+
+    const isValid = validate();
+    if (!isValid) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await signup(email.trim(), password);
+      rootNavigation?.navigate('Main');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to create your account.';
+      showErrorToast(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [submitting, validate, signup, email, password, rootNavigation]);
+
+  const handleNavigateToLogin = useCallback(() => {
+    navigation.navigate('Login');
+  }, [navigation]);
+
+  return (
+    <SafeAreaView style={[layout.screen, styles.container]}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.keyboardAvoidingView}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>Create your account</Text>
+          <Text style={styles.subtitle}>Sign up to start sending and receiving crypto instantly.</Text>
+
+          <View style={styles.form}>
+            <Input
+              label="Email"
+              placeholder="you@example.com"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              textContentType="emailAddress"
+              value={email}
+              onChangeText={value => {
+                setEmail(value);
+                if (errors.email) {
+                  setErrors(prev => ({ ...prev, email: undefined }));
+                }
+              }}
+              error={errors.email}
+            />
+
+            <Input
+              label="Password"
+              placeholder="Enter password"
+              secureTextEntry
+              textContentType="password"
+              value={password}
+              onChangeText={value => {
+                setPassword(value);
+                if (errors.password) {
+                  setErrors(prev => ({ ...prev, password: undefined }));
+                }
+              }}
+              error={errors.password}
+            />
+
+            <Input
+              label="Confirm Password"
+              placeholder="Re-enter password"
+              secureTextEntry
+              textContentType="password"
+              value={confirmPassword}
+              onChangeText={value => {
+                setConfirmPassword(value);
+                if (errors.confirmPassword) {
+                  setErrors(prev => ({ ...prev, confirmPassword: undefined }));
+                }
+              }}
+              error={errors.confirmPassword}
+            />
+
+            <Text style={styles.helperText}>{helperText}</Text>
+
+            <Button label="Sign Up" onPress={handleSignup} loading={submitting} fullWidth />
+          </View>
+
+          <Text style={styles.footerText}>
+            Already have an account?{' '}
+            <Text style={styles.footerLink} onPress={handleNavigateToLogin}>
+              Log in
+            </Text>
+          </Text>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
+    backgroundColor: colors.background,
+    paddingHorizontal: 0,
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
     paddingTop: 48,
+    paddingBottom: 32,
   },
   title: {
     ...typography.heading,
-    marginBottom: 12,
+    marginBottom: 8,
   },
   subtitle: {
     ...typography.body,
+    color: colors.textSecondary,
+    marginBottom: 32,
+  },
+  form: {
+    marginBottom: 32,
+  },
+  helperText: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginTop: -8,
+    marginBottom: 16,
+  },
+  footerText: {
+    ...typography.body,
+    color: colors.textSecondary,
+    textAlign: 'center',
+  },
+  footerLink: {
+    color: colors.accent,
+    fontWeight: '700',
   },
 });
 

--- a/screens/SplashScreen.tsx
+++ b/screens/SplashScreen.tsx
@@ -12,7 +12,11 @@ export type SplashScreenNavigation = NativeStackNavigationProp<AuthStackParamLis
 const SplashScreen: React.FC = () => {
   const navigation = useNavigation<SplashScreenNavigation>();
   const rootNavigation = navigation.getParent<NativeStackNavigationProp<RootStackParamList>>();
-  const { status } = useAuth();
+  const { status, initialize } = useAuth();
+
+  useEffect(() => {
+    void initialize();
+  }, [initialize]);
 
   useEffect(() => {
     if (status === 'loading') {

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,10 +1,32 @@
-import axios from 'axios';
+const MOCK_LATENCY = 1200;
 
-const API_BASE_URL = 'https://api.hashpay.app';
+const createMockToken = (email: string) => {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const encodedEmail = email.replace(/[^a-zA-Z0-9]/g, '_');
+  return `mock.${encodedEmail}.${issuedAt}`;
+};
 
-export const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 15000,
-});
+const delay = (ms: number) =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
 
-// Interceptors can be added here once auth flow is wired up
+export const signup = async (email: string, password: string): Promise<string> => {
+  await delay(MOCK_LATENCY);
+
+  if (!email || !password) {
+    throw new Error('Missing signup credentials.');
+  }
+
+  return createMockToken(email.trim().toLowerCase());
+};
+
+export const login = async (email: string, password: string): Promise<string> => {
+  await delay(MOCK_LATENCY);
+
+  if (!email || !password) {
+    throw new Error('Missing login credentials.');
+  }
+
+  return createMockToken(email.trim().toLowerCase());
+};


### PR DESCRIPTION
## Summary
- implement signup and login screens with validation, secure token storage, and biometric login option
- expand the auth context to manage signup/login/logout flows, bootstrap persisted tokens, and expose biometric authentication helpers
- update shared inputs/buttons for error/loading states and mock the auth API responses used by the new screens

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0054160c0832fb8b8e920caa66a0d