### PR TITLE
Feat: add wallet home, send, and receive flows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,12 +14,14 @@ import LoginScreen from './screens/LoginScreen';
 import HomeScreen from './screens/HomeScreen';
 import HistoryScreen from './screens/HistoryScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import SendScreen from './screens/SendScreen';
+import ReceiveScreen from './screens/ReceiveScreen';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { BalanceProvider } from './contexts/BalanceContext';
 import { Button } from './components/Button';
 import { colors } from './theme/colors';
 import { typography } from './theme/styles';
-import { AuthStackParamList, MainTabParamList, RootStackParamList } from './types/navigation';
+import { AuthStackParamList, HomeStackParamList, MainTabParamList, RootStackParamList } from './types/navigation';
 
 class ScreenErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
   public state = { hasError: false };
@@ -64,6 +66,15 @@ const withScreenErrorBoundary = <P extends object>(Component: React.ComponentTyp
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
+const HomeStack = createNativeStackNavigator<HomeStackParamList>();
+
+const HomeStackNavigator: React.FC = () => (
+  <HomeStack.Navigator screenOptions={{ headerShown: false }}>
+    <HomeStack.Screen name="HomeMain" component={withScreenErrorBoundary(HomeScreen)} />
+    <HomeStack.Screen name="Send" component={withScreenErrorBoundary(SendScreen)} />
+    <HomeStack.Screen name="Receive" component={withScreenErrorBoundary(ReceiveScreen)} />
+  </HomeStack.Navigator>
+);
 
 const AuthStackNavigator: React.FC = () => (
   <AuthStack.Navigator screenOptions={{ headerShown: false }} initialRouteName="Splash">
@@ -96,7 +107,7 @@ const MainTabsNavigator: React.FC = () => (
       },
     })}
   >
-    <Tab.Screen name="Home" component={withScreenErrorBoundary(HomeScreen)} />
+    <Tab.Screen name="Home" component={HomeStackNavigator} />
     <Tab.Screen name="History" component={withScreenErrorBoundary(HistoryScreen)} />
     <Tab.Screen name="Settings" component={withScreenErrorBoundary(SettingsScreen)} />
   </Tab.Navigator>

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -6,6 +6,7 @@ export interface InputProps extends TextInputProps {
   label?: string;
   containerStyle?: StyleProp<ViewStyle>;
   error?: string;
+  numeric?: boolean;
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -15,6 +16,8 @@ export const Input: React.FC<InputProps> = ({
   onFocus,
   onBlur,
   secureTextEntry,
+  numeric = false,
+  keyboardType,
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -45,6 +48,7 @@ export const Input: React.FC<InputProps> = ({
         onFocus={handleFocus}
         onBlur={handleBlur}
         secureTextEntry={secureTextEntry}
+        keyboardType={numeric ? 'decimal-pad' : keyboardType}
         {...rest}
       />
       <View

--- a/components/QRCode.tsx
+++ b/components/QRCode.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import QRCodeSVG from 'react-native-qrcode-svg';
+import { colors } from '../theme/colors';
+
+export interface QRCodeProps {
+  value: string;
+  size?: number;
+}
+
+export const QRCode: React.FC<QRCodeProps> = ({ value, size = 220 }) => {
+  const safeValue = value?.trim().length ? value : ' ';
+
+  return (
+    <View style={styles.container}>
+      <QRCodeSVG value={safeValue} size={size} backgroundColor="transparent" color={colors.textPrimary} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    backgroundColor: colors.cardBackground,
+    borderRadius: 24,
+    alignSelf: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    shadowColor: colors.accent,
+    shadowOpacity: 0.2,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 6,
+  },
+});
+
+export default QRCode;

--- a/contexts/BalanceContext.tsx
+++ b/contexts/BalanceContext.tsx
@@ -1,26 +1,52 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { getBalance, sendBTC as sendBTCApi } from '../services/api';
+
+export interface SendBTCResult {
+  txid: string;
+}
 
 export interface BalanceContextValue {
   balance: number;
+  fiatBalance: number;
   refreshBalance: () => Promise<void>;
+  sendBTC: (address: string, amount: number) => Promise<SendBTCResult>;
 }
 
 const BalanceContext = createContext<BalanceContextValue | undefined>(undefined);
 
 export const BalanceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [balance, setBalance] = useState<number>(0);
+  const [fiatBalance, setFiatBalance] = useState<number>(0);
 
-  const refreshBalance = async () => {
-    // Placeholder implementation until API integration is complete
-    setBalance(prev => prev);
-  };
+  const refreshBalance = useCallback(async () => {
+    const { btc, fiat } = await getBalance();
+    setBalance(btc);
+    setFiatBalance(fiat);
+  }, []);
+
+  useEffect(() => {
+    refreshBalance().catch(error => {
+      console.error('Failed to refresh balance:', error);
+    });
+  }, [refreshBalance]);
+
+  const sendBTC = useCallback(
+    async (address: string, amount: number) => {
+      const result = await sendBTCApi(address, amount);
+      await refreshBalance();
+      return result;
+    },
+    [refreshBalance]
+  );
 
   const value = useMemo(
     () => ({
       balance,
+      fiatBalance,
       refreshBalance,
+      sendBTC,
     }),
-    [balance]
+    [balance, fiatBalance, refreshBalance, sendBTC]
   );
 
   return <BalanceContext.Provider value={value}>{children}</BalanceContext.Provider>;

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,24 +1,110 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Button } from '../components/Button';
+import { useBalance } from '../contexts/BalanceContext';
+import { colors } from '../theme/colors';
 import { layout, typography } from '../theme/styles';
+import { HomeStackParamList } from '../types/navigation';
 
-const HomeScreen: React.FC = () => (
-  <SafeAreaView style={[layout.screen, styles.container]}>
-    <Text style={styles.title}>Home</Text>
-    <Text style={styles.subtitle}>Wallet overview coming soon.</Text>
-  </SafeAreaView>
-);
+const formatBTC = (amount: number): string => amount.toFixed(8);
+
+const formatUSD = (amount: number): string =>
+  `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const HomeScreen: React.FC = () => {
+  const { balance, fiatBalance, refreshBalance } = useBalance();
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+  const [refreshing, setRefreshing] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      refreshBalance().catch(error => {
+        console.error('Failed to refresh wallet balance:', error);
+      });
+    }, [refreshBalance])
+  );
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refreshBalance();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refreshBalance]);
+
+  const handleNavigateToSend = useCallback(() => {
+    navigation.navigate('Send');
+  }, [navigation]);
+
+  const handleNavigateToReceive = useCallback(() => {
+    navigation.navigate('Receive');
+  }, [navigation]);
+
+  const formattedBTC = useMemo(() => formatBTC(balance), [balance]);
+  const formattedUSD = useMemo(() => formatUSD(fiatBalance), [fiatBalance]);
+
+  return (
+    <SafeAreaView style={[layout.screen, styles.safeArea]}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.accent} />}
+      >
+        <Animated.View entering={FadeIn.duration(600)} style={styles.balanceContainer}>
+          <Text style={styles.balanceLabel}>Total Balance</Text>
+          <Text style={styles.balanceValue}>{formattedBTC} BTC</Text>
+          <Text style={styles.balanceFiat}>{formattedUSD}</Text>
+        </Animated.View>
+
+        <View style={styles.actionsContainer}>
+          <Button label="Send" onPress={handleNavigateToSend} fullWidth style={[styles.actionButton, styles.firstAction]} />
+          <Button label="Receive" onPress={handleNavigateToReceive} fullWidth style={styles.actionButton} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
 
 const styles = StyleSheet.create({
-  container: {
-    paddingTop: 48,
+  safeArea: {
+    paddingTop: 32,
   },
-  title: {
-    ...typography.heading,
+  contentContainer: {
+    flexGrow: 1,
+    justifyContent: 'space-between',
+    paddingBottom: 48,
+  },
+  balanceContainer: {
+    marginTop: 24,
+  },
+  balanceLabel: {
+    ...typography.subheading,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
     marginBottom: 12,
   },
-  subtitle: {
+  balanceValue: {
+    fontSize: 48,
+    fontWeight: '800',
+    color: colors.textPrimary,
+  },
+  balanceFiat: {
     ...typography.body,
+    color: colors.textSecondary,
+    marginTop: 8,
+  },
+  actionsContainer: {
+    marginTop: 48,
+  },
+  actionButton: {
+    height: 64,
+    borderRadius: 18,
+  },
+  firstAction: {
+    marginBottom: 16,
   },
 });
 

--- a/screens/ReceiveScreen.tsx
+++ b/screens/ReceiveScreen.tsx
@@ -1,24 +1,154 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
+import * as Clipboard from 'expo-clipboard';
+import { Button } from '../components/Button';
+import { QRCode } from '../components/QRCode';
+import { colors } from '../theme/colors';
 import { layout, typography } from '../theme/styles';
+import { getAddress } from '../services/api';
 
-const ReceiveScreen: React.FC = () => (
-  <SafeAreaView style={[layout.screen, styles.container]}>
-    <Text style={styles.title}>Receive Bitcoin</Text>
-    <Text style={styles.subtitle}>Receive flow coming soon.</Text>
-  </SafeAreaView>
-);
+const showToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('HASH', message);
+  }
+};
+
+const ReceiveScreen: React.FC = () => {
+  const [address, setAddress] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAddress = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await getAddress();
+      setAddress(result);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to load address.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAddress().catch(err => {
+      console.error('Failed to load receive address:', err);
+    });
+  }, [fetchAddress]);
+
+  const handleCopyAddress = useCallback(async () => {
+    if (!address) {
+      return;
+    }
+
+    try {
+      await Clipboard.setStringAsync(address);
+      showToast('Address copied to clipboard');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to copy address.';
+      showToast(message);
+    }
+  }, [address]);
+
+  return (
+    <SafeAreaView style={[layout.screen, styles.safeArea]}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Receive Bitcoin</Text>
+        <Text style={styles.subtitle}>Share this address or QR code to receive BTC payments.</Text>
+
+        <View style={styles.qrWrapper}>
+          {loading ? (
+            <ActivityIndicator size="large" color={colors.accent} />
+          ) : error ? (
+            <View style={styles.errorContainer}>
+              <Text style={styles.errorText}>{error}</Text>
+              <Button label="Try Again" onPress={fetchAddress} style={styles.retryButton} />
+            </View>
+          ) : (
+            <Animated.View entering={FadeIn.duration(600)}>
+              <QRCode value={address ?? ''} />
+            </Animated.View>
+          )}
+        </View>
+
+        {address ? (
+          <View style={styles.addressSection}>
+            <Text style={styles.addressLabel}>Your BTC Address</Text>
+            <Text style={styles.addressValue} selectable>{address}</Text>
+            <Button label="Copy Address" onPress={handleCopyAddress} fullWidth style={styles.copyButton} />
+          </View>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+};
 
 const styles = StyleSheet.create({
+  safeArea: {
+    paddingTop: 32,
+  },
   container: {
-    paddingTop: 48,
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingBottom: 48,
   },
   title: {
     ...typography.heading,
-    marginBottom: 12,
+    marginBottom: 8,
   },
   subtitle: {
     ...typography.body,
+    color: colors.textSecondary,
+    marginBottom: 32,
+  },
+  qrWrapper: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexGrow: 1,
+  },
+  errorContainer: {
+    alignItems: 'center',
+  },
+  errorText: {
+    ...typography.body,
+    color: colors.error,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  retryButton: {
+    minWidth: 160,
+  },
+  addressSection: {
+    marginTop: 32,
+  },
+  addressLabel: {
+    ...typography.subheading,
+    color: colors.textSecondary,
+    marginBottom: 12,
+  },
+  addressValue: {
+    ...typography.body,
+    ...typography.monospace,
+    fontSize: 16,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  copyButton: {
+    alignSelf: 'stretch',
   },
 });
 

--- a/screens/SendScreen.tsx
+++ b/screens/SendScreen.tsx
@@ -1,24 +1,361 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner';
+import Animated, { Easing, useAnimatedStyle, useSharedValue, withSequence, withTiming } from 'react-native-reanimated';
+import { Button } from '../components/Button';
+import { Input } from '../components/Input';
+import { useBalance } from '../contexts/BalanceContext';
+import { colors } from '../theme/colors';
 import { layout, typography } from '../theme/styles';
+import { HomeStackParamList } from '../types/navigation';
 
-const SendScreen: React.FC = () => (
-  <SafeAreaView style={[layout.screen, styles.container]}>
-    <Text style={styles.title}>Send Bitcoin</Text>
-    <Text style={styles.subtitle}>Send flow coming soon.</Text>
-  </SafeAreaView>
-);
+const showToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('HASH', message);
+  }
+};
+
+const formatBTC = (value: number): string => value.toFixed(8);
+
+const SendScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+  const { sendBTC } = useBalance();
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isScannerVisible, setIsScannerVisible] = useState(false);
+  const [hasCameraPermission, setHasCameraPermission] = useState<boolean | null>(null);
+
+  const rippleScale = useSharedValue(0);
+
+  const triggerRipple = useCallback(() => {
+    rippleScale.value = 0.001;
+    rippleScale.value = withSequence(
+      withTiming(1, { duration: 420, easing: Easing.out(Easing.cubic) }),
+      withTiming(0, { duration: 520, easing: Easing.in(Easing.cubic) })
+    );
+  }, [rippleScale]);
+
+  const rippleStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: rippleScale.value }],
+    opacity: rippleScale.value === 0 ? 0 : 0.22,
+  }));
+
+  const amountValue = useMemo(() => {
+    const parsed = Number.parseFloat(amount);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [amount]);
+
+  const networkFee = useMemo(() => (amountValue > 0 ? Math.max(0.00001, amountValue * 0.0015) : 0), [amountValue]);
+  const serviceFee = useMemo(() => (amountValue > 0 ? Math.max(0.00001, amountValue * 0.0005) : 0), [amountValue]);
+  const total = useMemo(() => amountValue + networkFee + serviceFee, [amountValue, networkFee, serviceFee]);
+
+  const handleAmountChange = useCallback((value: string) => {
+    const sanitized = value.replace(/[^0-9.]/g, '');
+    if (!sanitized) {
+      setAmount('');
+      return;
+    }
+
+    const [wholePart, ...decimalParts] = sanitized.split('.');
+    const decimal = decimalParts.join('').slice(0, 8);
+    const nextValue = decimalParts.length > 0 ? `${wholePart}.${decimal}` : wholePart;
+    setAmount(nextValue);
+  }, []);
+
+  const requestCameraPermission = useCallback(async () => {
+    if (hasCameraPermission === true) {
+      return true;
+    }
+
+    const { status } = await BarCodeScanner.requestPermissionsAsync();
+    const granted = status === 'granted';
+    setHasCameraPermission(granted);
+
+    if (!granted) {
+      showToast('Camera permission is required to scan QR codes.');
+    }
+
+    return granted;
+  }, [hasCameraPermission]);
+
+  const handleScanPress = useCallback(async () => {
+    const granted = await requestCameraPermission();
+    if (granted) {
+      setIsScannerVisible(true);
+    }
+  }, [requestCameraPermission]);
+
+  const handleBarCodeScanned = useCallback(
+    (event: BarCodeScannerResult) => {
+      setIsScannerVisible(false);
+      if (event?.data) {
+        setRecipient(event.data.trim());
+        showToast('Address scanned');
+      }
+    },
+    []
+  );
+
+  const handleConfirm = useCallback(async () => {
+    const trimmedAddress = recipient.trim();
+
+    if (!trimmedAddress || amountValue <= 0) {
+      showToast('Enter a valid address and amount to continue.');
+      return;
+    }
+
+    try {
+      triggerRipple();
+      setIsSubmitting(true);
+      await sendBTC(trimmedAddress, amountValue);
+      showToast('Transaction Sent!');
+      navigation.goBack();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to send BTC.';
+      showToast(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [amountValue, navigation, recipient, sendBTC, triggerRipple]);
+
+  const isConfirmDisabled = !recipient.trim() || amountValue <= 0 || isSubmitting;
+
+  return (
+    <View style={styles.root}>
+      <Animated.View pointerEvents="none" style={[styles.ripple, rippleStyle]} />
+      <SafeAreaView style={[layout.screen, styles.safeArea]}>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? 24 : 0}
+        >
+          <ScrollView contentContainerStyle={styles.contentContainer} keyboardShouldPersistTaps="handled">
+            <View style={styles.headerSection}>
+              <Text style={styles.title}>Send Bitcoin</Text>
+              <Text style={styles.subtitle}>Review the details carefully before confirming your transfer.</Text>
+            </View>
+
+            <View style={styles.formSection}>
+              <Input
+                label="Recipient Address"
+                placeholder="bc1..."
+                autoCapitalize="none"
+                autoCorrect={false}
+                value={recipient}
+                onChangeText={setRecipient}
+                containerStyle={styles.field}
+              />
+
+              <Button label="Scan QR" onPress={handleScanPress} style={styles.scanButton} />
+
+              <Input
+                label="Amount (BTC)"
+                placeholder="0.00000000"
+                value={amount}
+                onChangeText={handleAmountChange}
+                numeric
+                keyboardType="decimal-pad"
+                containerStyle={styles.field}
+              />
+            </View>
+
+            <View style={styles.feesContainer}>
+              <Text style={styles.sectionTitle}>Summary</Text>
+              <View style={styles.feeRow}>
+                <Text style={styles.feeLabel}>Amount</Text>
+                <Text style={styles.feeValue}>{formatBTC(amountValue)} BTC</Text>
+              </View>
+              <View style={styles.feeRow}>
+                <Text style={styles.feeLabel}>Network Fee</Text>
+                <Text style={styles.feeValue}>{formatBTC(networkFee)} BTC</Text>
+              </View>
+              <View style={styles.feeRow}>
+                <Text style={styles.feeLabel}>Service Fee</Text>
+                <Text style={styles.feeValue}>{formatBTC(serviceFee)} BTC</Text>
+              </View>
+              <View style={[styles.feeRow, styles.totalRow]}>
+                <Text style={styles.totalLabel}>Total</Text>
+                <Text style={styles.totalValue}>{formatBTC(total)} BTC</Text>
+              </View>
+            </View>
+
+            <View style={styles.buttonWrapper}>
+              <Button
+                label={isSubmitting ? 'Sending...' : 'Confirm Transfer'}
+                onPress={handleConfirm}
+                disabled={isConfirmDisabled}
+                loading={isSubmitting}
+                fullWidth
+              />
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+
+      <Modal visible={isScannerVisible} animationType="fade" transparent onRequestClose={() => setIsScannerVisible(false)}>
+        <View style={styles.scannerOverlay}>
+          <View style={styles.scannerCard}>
+            <Text style={styles.scannerTitle}>Scan recipient QR</Text>
+            <View style={styles.scannerFrame}>
+              <BarCodeScanner
+                onBarCodeScanned={handleBarCodeScanned}
+                style={StyleSheet.absoluteFillObject}
+              />
+            </View>
+            {hasCameraPermission === false ? (
+              <Text style={styles.permissionText}>Enable camera permissions in settings to scan addresses.</Text>
+            ) : null}
+              <Button label="Cancel" onPress={() => setIsScannerVisible(false)} fullWidth style={styles.scannerButton} />
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
-  container: {
-    paddingTop: 48,
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    paddingTop: 32,
+  },
+  flex: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    paddingBottom: 48,
+  },
+  headerSection: {
+    marginBottom: 24,
   },
   title: {
     ...typography.heading,
-    marginBottom: 12,
+    marginBottom: 8,
   },
   subtitle: {
     ...typography.body,
+    color: colors.textSecondary,
+    marginTop: 4,
+  },
+  formSection: {
+    marginBottom: 24,
+  },
+  field: {
+    marginBottom: 16,
+  },
+  scanButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 28,
+    marginBottom: 16,
+  },
+  feesContainer: {
+    ...layout.card,
+    marginBottom: 32,
+  },
+  sectionTitle: {
+    ...typography.subheading,
+    color: colors.textPrimary,
+    marginBottom: 12,
+  },
+  feeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  feeLabel: {
+    ...typography.body,
+    color: colors.textSecondary,
+  },
+  feeValue: {
+    ...typography.body,
+    fontWeight: '600',
+  },
+  totalRow: {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: 12,
+    marginTop: 8,
+    marginBottom: 0,
+  },
+  totalLabel: {
+    ...typography.subheading,
+    color: colors.textPrimary,
+  },
+  totalValue: {
+    ...typography.subheading,
+    fontWeight: '700',
+  },
+  buttonWrapper: {
+    marginTop: 16,
+  },
+  ripple: {
+    position: 'absolute',
+    width: 600,
+    height: 600,
+    borderRadius: 300,
+    backgroundColor: colors.accent,
+    alignSelf: 'center',
+    top: -200,
+  },
+  scannerOverlay: {
+    flex: 1,
+    backgroundColor: '#000000CC',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  scannerCard: {
+    width: '100%',
+    backgroundColor: colors.cardBackground,
+    borderRadius: 20,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  scannerTitle: {
+    ...typography.subheading,
+    color: colors.textPrimary,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  scannerFrame: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 18,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: colors.accent,
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  permissionText: {
+    ...typography.caption,
+    color: colors.error,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  scannerButton: {
+    marginTop: 8,
   },
 });
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,5 +1,7 @@
 const MOCK_LATENCY = 1200;
 
+const MOCK_BTC_PRICE = 42650;
+
 const createMockToken = (email: string) => {
   const issuedAt = Math.floor(Date.now() / 1000);
   const encodedEmail = email.replace(/[^a-zA-Z0-9]/g, '_');
@@ -29,4 +31,39 @@ export const login = async (email: string, password: string): Promise<string> =>
   }
 
   return createMockToken(email.trim().toLowerCase());
+};
+
+export const getBalance = async (): Promise<{ btc: number; fiat: number }> => {
+  await delay(MOCK_LATENCY / 2);
+
+  const btc = Number((Math.random() * 0.75 + 0.05).toFixed(8));
+  const fiat = Number((btc * MOCK_BTC_PRICE).toFixed(2));
+
+  return { btc, fiat };
+};
+
+export const sendBTC = async (address: string, amount: number): Promise<{ txid: string }> => {
+  await delay(MOCK_LATENCY);
+
+  if (!address || amount <= 0) {
+    throw new Error('Invalid transaction payload.');
+  }
+
+  if (!address.startsWith('1') && !address.startsWith('3') && !address.startsWith('bc1')) {
+    throw new Error('Unsupported BTC address format.');
+  }
+
+  if (amount > 2) {
+    throw new Error('Amount exceeds mock transfer limit.');
+  }
+
+  const txid = `mock-txid-${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
+
+  return { txid };
+};
+
+export const getAddress = async (): Promise<string> => {
+  await delay(MOCK_LATENCY / 3);
+
+  return 'bc1qhashpaymockaddress0000000000000000000000';
 };

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -15,3 +15,9 @@ export type RootStackParamList = {
   Auth: undefined;
   Main: undefined;
 };
+
+export type HomeStackParamList = {
+  HomeMain: undefined;
+  Send: undefined;
+  Receive: undefined;
+};


### PR DESCRIPTION
## Summary
- wire BalanceContext into mocked wallet APIs for refreshing balances and sending BTC
- implement new Home, Send, and Receive screens with animations, QR support, and toast messaging
- extend shared components/utilities and navigation to support numeric inputs, QR codes, and wallet stack routing

## Testing
- not run (react native project has no automated test commands configured)

------
https://chatgpt.com/codex/tasks/task_e_68e0478c0ac0832fa36249b90334a222