### PR TITLE
Feat: scaffold database migrations and repositories

### DIFF
--- a/backend/migrations/001_create_users_table.js
+++ b/backend/migrations/001_create_users_table.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.up = (pgm) => {
+  pgm.createTable('users', {
+    id: 'id',
+    email: { type: 'text', notNull: true, unique: true },
+    password_hash: { type: 'text', notNull: true },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+  });
+};
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.down = (pgm) => {
+  pgm.dropTable('users');
+};

--- a/backend/migrations/002_create_wallets_table.js
+++ b/backend/migrations/002_create_wallets_table.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.up = (pgm) => {
+  pgm.createTable('wallets', {
+    id: 'id',
+    user_id: { type: 'integer', notNull: true, references: 'users', onDelete: 'cascade' },
+    btc_address: { type: 'text', notNull: true },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+  });
+
+  pgm.addIndex('wallets', ['user_id']);
+};
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.down = (pgm) => {
+  pgm.dropTable('wallets');
+};

--- a/backend/migrations/003_create_transactions_table.js
+++ b/backend/migrations/003_create_transactions_table.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.up = (pgm) => {
+  pgm.createTable('transactions', {
+    id: 'id',
+    user_id: { type: 'integer', notNull: true, references: 'users', onDelete: 'cascade' },
+    txid: { type: 'text' },
+    amount_sats: { type: 'bigint', notNull: true },
+    network_fee: { type: 'bigint', notNull: true },
+    service_fee: { type: 'bigint', notNull: true },
+    status: {
+      type: 'text',
+      notNull: true,
+      check: "status IN ('pending','confirmed','failed')"
+    },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+  });
+
+  pgm.addIndex('transactions', ['user_id']);
+  pgm.addIndex('transactions', ['txid']);
+};
+
+/** @param {import('node-pg-migrate').MigrationBuilder} pgm */
+exports.down = (pgm) => {
+  pgm.dropTable('transactions');
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/src/server.js",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "format": "prettier --check ."
+    "format": "prettier --check .",
+    "migrate": "node scripts/run-migrations.js"
   },
   "author": "",
   "license": "MIT",
@@ -35,6 +36,7 @@
     "eslint": "^8.56.0",
     "prettier": "^3.2.5",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "node-pg-migrate": "^7.6.1"
   }
 }

--- a/backend/scripts/run-migrations.js
+++ b/backend/scripts/run-migrations.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+
+const { run } = require('node-pg-migrate');
+
+const buildDatabaseUrl = () => {
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL;
+  }
+
+  const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS } = process.env;
+
+  if (DB_HOST && DB_PORT && DB_NAME && DB_USER && DB_PASS) {
+    const user = encodeURIComponent(DB_USER);
+    const password = encodeURIComponent(DB_PASS);
+    return `postgresql://${user}:${password}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
+  }
+
+  throw new Error(
+    'DATABASE_URL or DB_HOST, DB_PORT, DB_NAME, DB_USER, and DB_PASS environment variables must be set to run migrations.'
+  );
+};
+
+run({
+  databaseUrl: buildDatabaseUrl(),
+  dir: 'migrations',
+  direction: 'up',
+  migrationsTable: 'pgmigrations'
+})
+  .then(() => {
+    // eslint-disable-next-line no-console
+    console.log('Database migrations completed successfully.');
+    process.exit(0);
+  })
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Database migrations failed.', error);
+    process.exit(1);
+  });

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -1,0 +1,25 @@
+import { Pool, PoolClient, QueryResult } from 'pg';
+import config from '../../config';
+
+const pool = new Pool({
+  host: config.database.host,
+  user: config.database.user,
+  password: config.database.password,
+  database: config.database.database,
+  port: config.database.port
+});
+
+pool.on('error', (error: Error) => {
+  // eslint-disable-next-line no-console
+  console.error('Unexpected database error', error);
+});
+
+export type QueryParams = ReadonlyArray<unknown>;
+
+export const query = async <T>(sql: string, params: QueryParams = []): Promise<QueryResult<T>> => {
+  return pool.query<T>(sql, params);
+};
+
+export const getClient = async (): Promise<PoolClient> => pool.connect();
+
+export default pool;

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,24 +1,2 @@
-import { Pool } from 'pg';
-import config from '../../config';
-
-const pool = new Pool({
-  host: config.database.host,
-  user: config.database.user,
-  password: config.database.password,
-  database: config.database.database,
-  port: config.database.port
-});
-
-pool.on('error', (err: Error) => {
-  // eslint-disable-next-line no-console
-  console.error('Unexpected database error', err);
-});
-
-export const query = async <T>(text: string, params?: unknown[]): Promise<T[]> => {
-  const result = await pool.query<T>(text, params);
-  return result.rows;
-};
-
-export const getClient = async () => pool.connect();
-
-export default pool;
+export * from './db';
+export { default } from './db';

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -1,0 +1,86 @@
+import { QueryResult } from 'pg';
+import { query } from '../db/db';
+
+export type TransactionStatus = 'pending' | 'confirmed' | 'failed';
+
+export interface Transaction {
+  id: number;
+  userId: number;
+  txid: string | null;
+  amountSats: string;
+  networkFee: string;
+  serviceFee: string;
+  status: TransactionStatus;
+  createdAt: Date;
+}
+
+const toBigIntParam = (value: bigint | number | string): string => {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    return Math.trunc(value).toString();
+  }
+
+  return value;
+};
+
+export class TransactionRepository {
+  public static async logTransaction(
+    userId: number,
+    txid: string | null,
+    amountSats: bigint | number | string,
+    networkFee: bigint | number | string,
+    serviceFee: bigint | number | string,
+    status: TransactionStatus
+  ): Promise<Transaction> {
+    const insertSql = `
+      INSERT INTO transactions (user_id, txid, amount_sats, network_fee, service_fee, status)
+      VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        id,
+        user_id AS "userId",
+        txid,
+        amount_sats::text AS "amountSats",
+        network_fee::text AS "networkFee",
+        service_fee::text AS "serviceFee",
+        status,
+        created_at AS "createdAt";
+    `;
+
+    const params = [
+      userId,
+      txid,
+      toBigIntParam(amountSats),
+      toBigIntParam(networkFee),
+      toBigIntParam(serviceFee),
+      status
+    ];
+
+    const result: QueryResult<Transaction> = await query<Transaction>(insertSql, params);
+    return result.rows[0];
+  }
+
+  public static async getTransactionsForUser(userId: number): Promise<Transaction[]> {
+    const selectSql = `
+      SELECT
+        id,
+        user_id AS "userId",
+        txid,
+        amount_sats::text AS "amountSats",
+        network_fee::text AS "networkFee",
+        service_fee::text AS "serviceFee",
+        status,
+        created_at AS "createdAt"
+      FROM transactions
+      WHERE user_id = $1
+      ORDER BY created_at DESC;
+    `;
+
+    const result: QueryResult<Transaction> = await query<Transaction>(selectSql, [userId]);
+    return result.rows;
+  }
+}
+
+export default TransactionRepository;

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -1,0 +1,49 @@
+import { QueryResult } from 'pg';
+import { query, QueryParams } from '../db/db';
+
+export interface User {
+  id: number;
+  email: string;
+  passwordHash: string;
+  createdAt: Date;
+}
+
+export class UserRepository {
+  public static async createUser(email: string, passwordHash: string): Promise<User> {
+    const insertSql = `
+      INSERT INTO users (email, password_hash)
+      VALUES ($1, $2)
+      RETURNING id, email, password_hash AS "passwordHash", created_at AS "createdAt";
+    `;
+
+    const params: QueryParams = [email, passwordHash];
+    const result: QueryResult<User> = await query<User>(insertSql, params);
+    return result.rows[0];
+  }
+
+  public static async findUserByEmail(email: string): Promise<User | null> {
+    const selectSql = `
+      SELECT id, email, password_hash AS "passwordHash", created_at AS "createdAt"
+      FROM users
+      WHERE email = $1
+      LIMIT 1;
+    `;
+
+    const result: QueryResult<User> = await query<User>(selectSql, [email]);
+    return result.rows[0] ?? null;
+  }
+
+  public static async findUserById(id: number): Promise<User | null> {
+    const selectSql = `
+      SELECT id, email, password_hash AS "passwordHash", created_at AS "createdAt"
+      FROM users
+      WHERE id = $1
+      LIMIT 1;
+    `;
+
+    const result: QueryResult<User> = await query<User>(selectSql, [id]);
+    return result.rows[0] ?? null;
+  }
+}
+
+export default UserRepository;

--- a/backend/src/repositories/WalletRepository.ts
+++ b/backend/src/repositories/WalletRepository.ts
@@ -1,0 +1,36 @@
+import { QueryResult } from 'pg';
+import { query } from '../db/db';
+
+export interface Wallet {
+  id: number;
+  userId: number;
+  btcAddress: string;
+  createdAt: Date;
+}
+
+export class WalletRepository {
+  public static async createWallet(userId: number, btcAddress: string): Promise<Wallet> {
+    const insertSql = `
+      INSERT INTO wallets (user_id, btc_address)
+      VALUES ($1, $2)
+      RETURNING id, user_id AS "userId", btc_address AS "btcAddress", created_at AS "createdAt";
+    `;
+
+    const result: QueryResult<Wallet> = await query<Wallet>(insertSql, [userId, btcAddress]);
+    return result.rows[0];
+  }
+
+  public static async getWalletsForUser(userId: number): Promise<Wallet[]> {
+    const selectSql = `
+      SELECT id, user_id AS "userId", btc_address AS "btcAddress", created_at AS "createdAt"
+      FROM wallets
+      WHERE user_id = $1
+      ORDER BY created_at DESC;
+    `;
+
+    const result: QueryResult<Wallet> = await query<Wallet>(selectSql, [userId]);
+    return result.rows;
+  }
+}
+
+export default WalletRepository;


### PR DESCRIPTION
## Summary
- add node-pg-migrate runner and SQL migrations for users, wallets, and transactions tables
- expose a typed PostgreSQL helper and repository classes for users, wallets, and transactions

## Testing
- npm run lint *(fails: ESLint 9 requires flat config; backend still uses .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e05e07ac1c832fb88385418c4505ae