### PR TITLE
Feat: add JWT authentication endpoints

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -1,0 +1,124 @@
+import { Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import config from '../../config';
+import UserRepository, { User } from '../repositories/UserRepository';
+
+const TOKEN_EXPIRY = '7d';
+const SALT_ROUNDS = 10;
+
+type AuthenticatedUser = Pick<User, 'id' | 'email' | 'createdAt'>;
+
+const toProfile = (user: User): AuthenticatedUser => ({
+  id: user.id,
+  email: user.email,
+  createdAt: user.createdAt
+});
+
+const isValidEmail = (value: unknown): value is string => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const trimmed = value.trim();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+  return emailRegex.test(trimmed);
+};
+
+const normalizeEmail = (email: string): string => email.trim().toLowerCase();
+
+const isValidPassword = (value: unknown): value is string => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.length >= 8 && value.length <= 128;
+};
+
+const generateToken = (userId: number): string => {
+  return jwt.sign({ userId }, config.jwt.secret, { expiresIn: TOKEN_EXPIRY });
+};
+
+class AuthController {
+  public static async signup(req: Request, res: Response): Promise<Response> {
+    try {
+      const { email, password } = req.body ?? {};
+
+      if (!isValidEmail(email)) {
+        return res.status(400).json({ message: 'A valid email address is required.' });
+      }
+
+      if (!isValidPassword(password)) {
+        return res
+          .status(400)
+          .json({ message: 'Password must be between 8 and 128 characters long.' });
+      }
+
+      const normalizedEmail = normalizeEmail(email);
+
+      const existingUser = await UserRepository.findUserByEmail(normalizedEmail);
+      if (existingUser) {
+        return res.status(409).json({ message: 'Email is already registered.' });
+      }
+
+      const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+      const user = await UserRepository.createUser(normalizedEmail, passwordHash);
+      const token = generateToken(user.id);
+
+      return res.status(201).json({ token, user: toProfile(user) });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error during signup:', error);
+      return res.status(500).json({ message: 'Unable to create account. Please try again.' });
+    }
+  }
+
+  public static async login(req: Request, res: Response): Promise<Response> {
+    try {
+      const { email, password } = req.body ?? {};
+
+      if (!isValidEmail(email) || !isValidPassword(password)) {
+        return res.status(400).json({ message: 'Invalid email or password.' });
+      }
+
+      const normalizedEmail = normalizeEmail(email);
+      const user = await UserRepository.findUserByEmail(normalizedEmail);
+      if (!user) {
+        return res.status(401).json({ message: 'Invalid credentials.' });
+      }
+
+      const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+      if (!isPasswordValid) {
+        return res.status(401).json({ message: 'Invalid credentials.' });
+      }
+
+      const token = generateToken(user.id);
+
+      return res.status(200).json({ token, user: toProfile(user) });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error during login:', error);
+      return res.status(500).json({ message: 'Unable to log in. Please try again.' });
+    }
+  }
+
+  public static async me(req: Request, res: Response): Promise<Response> {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ message: 'Authentication required.' });
+      }
+
+      const user = await UserRepository.findUserById(userId);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found.' });
+      }
+
+      return res.status(200).json({ user: toProfile(user) });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error fetching user profile:', error);
+      return res.status(500).json({ message: 'Unable to retrieve profile.' });
+    }
+  }
+}
+
+export default AuthController;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import config from '../../config';
+
+interface JwtPayload {
+  userId: number;
+  iat?: number;
+  exp?: number;
+}
+
+export const authMiddleware = (req: Request, res: Response, next: NextFunction): Response | void => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authentication required.' });
+  }
+
+  const token = authHeader.slice(7).trim();
+
+  if (!token) {
+    return res.status(401).json({ message: 'Authentication required.' });
+  }
+
+  try {
+    const payload = jwt.verify(token, config.jwt.secret) as JwtPayload;
+    req.user = { id: payload.userId };
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Invalid or expired token.' });
+  }
+};
+
+export default authMiddleware;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import AuthController from '../controllers/AuthController';
+import { authMiddleware } from '../middleware/auth';
+
+const router = Router();
+
+router.post('/signup', AuthController.signup);
+router.post('/login', AuthController.login);
+router.get('/me', authMiddleware, AuthController.me);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import morgan from 'morgan';
 import cors from 'cors';
 import config from '../config';
 import './db';
+import authRoutes from './routes/auth';
 
 const app: Application = express();
 
@@ -11,6 +12,8 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 app.use(morgan('combined'));
+
+app.use('/auth', authRoutes);
 
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,9 @@
+import 'express-serve-static-core';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: {
+      id: number;
+    };
+  }
+}

--- a/backend/tests/auth.http
+++ b/backend/tests/auth.http
@@ -1,0 +1,21 @@
+### Signup a new user
+POST http://localhost:3000/auth/signup
+Content-Type: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Sup3rSecur3!"
+}
+
+### Login with existing user
+POST http://localhost:3000/auth/login
+Content-Type: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Sup3rSecur3!"
+}
+
+### Fetch authenticated profile
+GET http://localhost:3000/auth/me
+Authorization: Bearer {{token}}


### PR DESCRIPTION
## Summary
- add an authentication controller that supports signup, login, and profile retrieval using JWTs
- implement JWT-based auth middleware and expose the /auth route group from the server
- provide example HTTP requests for exercising the new auth endpoints

## Testing
- npm run build *(fails: backend dependencies such as @types/node are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05ff3782c832f9acbc19b1ffdbd94