### PR TITLE
Implement wallet endpoints and Bitcoin RPC integration

### DIFF
--- a/backend/src/controllers/WalletController.ts
+++ b/backend/src/controllers/WalletController.ts
@@ -1,0 +1,111 @@
+import { Request, Response } from 'express';
+import bitcoinService from '../services/BitcoinService';
+import TransactionRepository from '../repositories/TransactionRepository';
+
+const SATS_PER_BTC = 100_000_000n;
+const SATS_PER_BTC_NUMBER = Number(SATS_PER_BTC);
+const SERVICE_FEE_PERCENT = 1n; // 1%
+
+const toSats = (amountBtc: number): bigint => BigInt(Math.round(amountBtc * SATS_PER_BTC_NUMBER));
+
+const isValidTestnetAddress = (address: string): boolean => {
+  if (!address || typeof address !== 'string') {
+    return false;
+  }
+
+  const normalized = address.trim();
+  const testnetRegex = /^(tb1[ac-hj-np-z02-9]{39,59}|bcrt1[ac-hj-np-z02-9]{39,59}|[mn2][1-9A-HJ-NP-Za-km-z]{25,39})$/;
+  return testnetRegex.test(normalized);
+};
+
+export class WalletController {
+  public static async balance(req: Request, res: Response): Promise<Response> {
+    if (!req.user?.id) {
+      return res.status(401).json({ message: 'Authentication required.' });
+    }
+
+    try {
+      const balance = await bitcoinService.getBalance();
+      return res.status(200).json({ balance });
+    } catch (error) {
+      return res.status(502).json({ message: 'Unable to fetch wallet balance.', error: (error as Error).message });
+    }
+  }
+
+  public static async address(req: Request, res: Response): Promise<Response> {
+    if (!req.user?.id) {
+      return res.status(401).json({ message: 'Authentication required.' });
+    }
+
+    try {
+      const address = await bitcoinService.getNewAddress();
+      return res.status(200).json({ address });
+    } catch (error) {
+      return res.status(502).json({ message: 'Unable to generate address.', error: (error as Error).message });
+    }
+  }
+
+  public static async send(req: Request, res: Response): Promise<Response> {
+    if (!req.user?.id) {
+      return res.status(401).json({ message: 'Authentication required.' });
+    }
+
+    const { address, amount } = req.body as { address?: string; amount?: number };
+
+    if (typeof amount !== 'number' || Number.isNaN(amount) || amount <= 0) {
+      return res.status(400).json({ message: 'Amount must be a positive number.' });
+    }
+
+    if (!address || !isValidTestnetAddress(address)) {
+      return res.status(400).json({ message: 'A valid Bitcoin testnet address is required.' });
+    }
+
+    try {
+      const amountSats = toSats(amount);
+      const serviceFeeSats = (amountSats * SERVICE_FEE_PERCENT) / 100n;
+      const sendAmountSats = amountSats - serviceFeeSats;
+
+      if (sendAmountSats <= 0n) {
+        return res.status(400).json({ message: 'Amount is too small after fees.' });
+      }
+
+      const sendAmountBtc = Number(sendAmountSats) / SATS_PER_BTC_NUMBER;
+      const txid = await bitcoinService.sendToAddress(address, sendAmountBtc);
+
+      const networkFeeSats = 0n;
+
+      const transaction = await TransactionRepository.logPendingSend(
+        req.user.id,
+        txid,
+        amountSats,
+        networkFeeSats,
+        serviceFeeSats
+      );
+
+      return res.status(201).json({
+        txid,
+        amountBtc: amount,
+        serviceFeeBtc: Number(serviceFeeSats) / SATS_PER_BTC_NUMBER,
+        networkFeeBtc: Number(networkFeeSats) / SATS_PER_BTC_NUMBER,
+        status: transaction.status
+      });
+    } catch (error) {
+      return res.status(502).json({ message: 'Unable to send transaction.', error: (error as Error).message });
+    }
+  }
+
+  public static async history(req: Request, res: Response): Promise<Response> {
+    if (!req.user?.id) {
+      return res.status(401).json({ message: 'Authentication required.' });
+    }
+
+    try {
+      const transactions = await TransactionRepository.getTransactionsForUser(req.user.id);
+      return res.status(200).json({ transactions });
+    } catch (error) {
+      return res.status(500).json({ message: 'Unable to fetch transaction history.', error: (error as Error).message });
+    }
+  }
+}
+
+export default WalletController;

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -62,6 +62,16 @@ export class TransactionRepository {
     return result.rows[0];
   }
 
+  public static async logPendingSend(
+    userId: number,
+    txid: string,
+    amountSats: bigint | number | string,
+    networkFee: bigint | number | string,
+    serviceFee: bigint | number | string
+  ): Promise<Transaction> {
+    return this.logTransaction(userId, txid, amountSats, networkFee, serviceFee, 'pending');
+  }
+
   public static async getTransactionsForUser(userId: number): Promise<Transaction[]> {
     const selectSql = `
       SELECT

--- a/backend/src/routes/wallet.ts
+++ b/backend/src/routes/wallet.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import WalletController from '../controllers/WalletController';
+import authMiddleware from '../middleware/auth';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+/**
+ * Example usage:
+ * GET /wallet/balance -> { "balance": 0.12345678 }
+ * GET /wallet/address -> { "address": "tb1qexample..." }
+ * POST /wallet/send { "address": "tb1qexample...", "amount": 0.001 }
+ *   -> { "txid": "...", "amountBtc": 0.001, "serviceFeeBtc": 0.00001, "networkFeeBtc": 0 }
+ * GET /wallet/history -> { "transactions": [ ... ] }
+ */
+router.get('/balance', WalletController.balance);
+router.get('/address', WalletController.address);
+router.post('/send', WalletController.send);
+router.get('/history', WalletController.history);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import config from '../config';
 import './db';
 import authRoutes from './routes/auth';
+import walletRoutes from './routes/wallet';
 
 const app: Application = express();
 
@@ -14,6 +15,7 @@ app.use(express.json());
 app.use(morgan('combined'));
 
 app.use('/auth', authRoutes);
+app.use('/wallet', walletRoutes);
 
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });

--- a/backend/src/services/BitcoinService.ts
+++ b/backend/src/services/BitcoinService.ts
@@ -1,29 +1,30 @@
 import axios, { AxiosInstance } from 'axios';
 import config from '../../config';
 
-interface RpcRequest {
+type JsonRpcRequest = {
   jsonrpc: '2.0';
   id: string;
   method: string;
   params: unknown[];
-}
+};
 
-interface RpcError {
+type JsonRpcError = {
   code: number;
   message: string;
-}
+};
 
-interface RpcResponse<T> {
+type JsonRpcResponse<T> = {
   result: T;
-  error: RpcError | null;
+  error: JsonRpcError | null;
   id: string;
-}
+};
 
-class BitcoinRpcService {
+export class BitcoinService {
   private readonly client: AxiosInstance;
 
   constructor() {
     const { host, port, username, password } = config.bitcoinRpc;
+
     this.client = axios.create({
       baseURL: `http://${host}:${port}`,
       auth: {
@@ -37,15 +38,15 @@ class BitcoinRpcService {
     });
   }
 
-  public async call<T>(method: string, params: unknown[] = []): Promise<T> {
-    const payload: RpcRequest = {
+  public async rpcCall<T>(method: string, params: unknown[] = []): Promise<T> {
+    const payload: JsonRpcRequest = {
       jsonrpc: '2.0',
       id: `${Date.now()}`,
       method,
       params
     };
 
-    const { data } = await this.client.post<RpcResponse<T>>('/', payload);
+    const { data } = await this.client.post<JsonRpcResponse<T>>('/', payload);
 
     if (data.error) {
       const error = new Error(data.error.message);
@@ -55,8 +56,20 @@ class BitcoinRpcService {
 
     return data.result;
   }
+
+  public async getBalance(): Promise<number> {
+    return this.rpcCall<number>('getbalance');
+  }
+
+  public async getNewAddress(): Promise<string> {
+    return this.rpcCall<string>('getnewaddress');
+  }
+
+  public async sendToAddress(address: string, amount: number): Promise<string> {
+    return this.rpcCall<string>('sendtoaddress', [address, amount]);
+  }
 }
 
-const bitcoinRpcService = new BitcoinRpcService();
+const bitcoinService = new BitcoinService();
 
-export default bitcoinRpcService;
+export default bitcoinService;


### PR DESCRIPTION
## Summary
- add a Bitcoin RPC service with helpers for balance, new addresses, and sending transactions
- implement wallet controller and routes that validate input, apply a 1% service fee, and log pending sends
- wire wallet routes into the server and extend the transaction repository with a helper for pending sends

## Testing
- npm run lint *(fails: ESLint cannot parse the workspace package.json from /.eslintrc.js)*
- npm run build *(fails: TypeScript missing @types/pg definitions in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68e061810a84832f9ac78ed3dcf1564c