### PR TITLE
Ensure backend migrations run before API startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ docker-compose up --build
 
 This starts Postgres, Bitcoin Core (testnet), and the API service. The API is available at `http://localhost:3000`.
 
+> **Note:** The API container now boots via `scripts/start-with-migrations.sh`, which applies pending migrations with `node scripts/run-migrations.js` before launching `node dist/src/server.js`. This keeps local environments aligned with production by ensuring schema changes are in place before the API accepts traffic.
+
 ### CI/CD
 
 GitHub Actions automatically:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ COPY .eslintrc.json ./
 COPY .prettierrc ./
 COPY src ./src
 COPY config ./config
+COPY scripts ./scripts
 
 RUN npm run build
 
@@ -28,5 +29,6 @@ COPY --from=deps /usr/src/app/node_modules ./node_modules
 RUN npm prune --omit=dev
 
 COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/scripts ./scripts
 
-CMD ["node", "dist/src/server.js"]
+ENTRYPOINT ["/usr/src/app/scripts/start-with-migrations.sh"]

--- a/backend/scripts/start-with-migrations.sh
+++ b/backend/scripts/start-with-migrations.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Ensure database migrations run before starting the server.
+node scripts/run-migrations.js
+
+exec node dist/src/server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    entrypoint:
+      - /usr/src/app/scripts/start-with-migrations.sh
     env_file:
       - backend/.env.example
     environment:


### PR DESCRIPTION
## Summary
- add a startup helper script that runs database migrations and launches the compiled server
- copy the helper into the production image and wire it up as the container entrypoint
- point docker-compose at the new script and document the auto-migration behavior for local workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e076fe6f44832fa080ccac0a1d35aa