### PR TITLE
Chore: separate backend env templates for dev and docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .expo-dev-client/
+backend/.env
+backend/.env.docker
+!backend/.env.example
+!backend/.env.docker

--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -1,10 +1,10 @@
 PORT=3000
-DB_HOST=localhost
+DB_HOST=postgres
 DB_USER=btcuser
 DB_PASS=btcpass
 DB_NAME=btcdb
 DB_PORT=5432
-BTC_RPC_HOST=localhost
+BTC_RPC_HOST=bitcoin
 BTC_RPC_PORT=18332
 BTC_RPC_USER=user
 BTC_RPC_PASS=password

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,33 @@
+# Backend Environment Configuration
+
+The backend expects environment variables to be provided via an `.env` file. Two templates are available depending on the workflow you are using.
+
+## Local development with `npm run dev`
+
+1. Copy `.env.example` to `.env`:
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+2. Update any secrets (for example `JWT_SECRET`) before starting the server.
+3. Run the development server:
+   ```bash
+   cd backend
+   npm install
+   npm run dev
+   ```
+
+The `.env.example` file defaults to `localhost` hosts so it works with services you run on your machine.
+
+## Docker Compose workflow
+
+1. Copy `.env.docker` to `.env` if you need to customise values locally, or allow Docker Compose to read the template directly.
+2. Start the stack from the repository root:
+   ```bash
+   docker-compose up --build
+   ```
+
+The `.env.docker` template retains the container hostnames used inside the Compose network, so the API container can reach Postgres and Bitcoin services without additional configuration.
+
+## Git ignore rules
+
+The repository `.gitignore` prevents committing runtime environment files (`backend/.env`). If you create a customised copy of `.env.docker`, rename it (for example `backend/.env.docker.local`) to keep it out of version control.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     env_file:
-      - backend/.env.example
+      - backend/.env.docker
     environment:
       NODE_ENV: production
     depends_on:


### PR DESCRIPTION
## Summary
- update the backend development template to default to localhost services
- add a docker-specific environment template and point docker-compose to it
- document environment setup workflows and ignore runtime env files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07774297c832fae9f8214f152360f