### PR TITLE
Chore: add Expo app config and public API base

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+
+const { extra } = Constants.expoConfig ?? {};
+const FALLBACK_API_BASE_URL = 'http://localhost:3000';
+
+const normalizeBaseUrl = (baseUrl = FALLBACK_API_BASE_URL) =>
+  baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+
+const API_BASE_URL = normalizeBaseUrl(extra?.apiBaseUrl);
+
+const buildApiUrl = (path) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  // Allow API routing to be controlled from Expo's public config.
+  return `${API_BASE_URL}${normalizedPath}`;
+};
 
 export default function App() {
   const [balance, setBalance] = useState("...");
@@ -7,13 +22,13 @@ export default function App() {
   const [amount, setAmount] = useState("");
 
   async function fetchBalance() {
-    const res = await fetch("http://localhost:3000/balance");
+    const res = await fetch(buildApiUrl('/balance'));
     const data = await res.json();
     setBalance(data.balance);
   }
 
   async function sendBTC() {
-    const res = await fetch("http://localhost:3000/send", {
+    const res = await fetch(buildApiUrl('/send'), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ address, amount: parseFloat(amount) })

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,32 @@
+import { ConfigContext, ExpoConfig } from 'expo/config';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
+const BITCOIN_RPC_URL = process.env.EXPO_PUBLIC_BITCOIN_RPC_URL ?? 'http://localhost:18332';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: 'Hashpay',
+  slug: 'hashpay',
+  version: '1.0.0',
+  scheme: 'hashpay',
+  orientation: 'portrait',
+  userInterfaceStyle: 'automatic',
+  ios: {
+    supportsTablet: false,
+    bundleIdentifier: 'com.hashpay.mobile',
+  },
+  android: {
+    package: 'com.hashpay.mobile',
+  },
+  extra: {
+    ...config.extra,
+    apiBaseUrl: API_BASE_URL,
+    bitcoinRpcUrl: BITCOIN_RPC_URL,
+  },
+  updates: {
+    fallbackToCacheTimeout: 0,
+    ...(config.updates ?? {}),
+  },
+  assetBundlePatterns: config.assetBundlePatterns ?? ['**/*'],
+  plugins: config.plugins ?? [],
+});

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "eslint . --ext .ts,.tsx",
-    "format": "prettier --check "**/*.{js,jsx,ts,tsx,json,md}"",
-    "format:write": "prettier --write "**/*.{js,jsx,ts,tsx,json,md}""
+    "format": "prettier --check '**/*.{js,jsx,ts,tsx,json,md}'",
+    "format:write": "prettier --write '**/*.{js,jsx,ts,tsx,json,md}'"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",


### PR DESCRIPTION
## Summary
- add an Expo app.config.ts that declares Hashpay metadata and exposes public API/RPC URLs
- update the legacy App.js fetch helpers to resolve endpoints from Expo public config
- fix the prettier scripts in package.json so the manifest remains valid JSON

## Testing
- npm install *(fails: registry.npmjs.org returns 403 in the execution environment)*
- npx expo start --offline *(fails: registry.npmjs.org returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0776ad814832f93f48c00efc74df2