### PR TITLE
Feat: add dual-currency wallet flows and conversion support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ import HistoryScreen from './screens/HistoryScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import SendScreen from './screens/SendScreen';
 import ReceiveScreen from './screens/ReceiveScreen';
+import ConvertScreen from './screens/ConvertScreen';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { BalanceProvider } from './contexts/BalanceContext';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
@@ -106,6 +107,7 @@ const HomeStackNavigator: React.FC = () => (
     <HomeStack.Screen name="HomeMain" component={withScreenErrorBoundary(HomeScreen)} />
     <HomeStack.Screen name="Send" component={withScreenErrorBoundary(SendScreen)} />
     <HomeStack.Screen name="Receive" component={withScreenErrorBoundary(ReceiveScreen)} />
+    <HomeStack.Screen name="Convert" component={withScreenErrorBoundary(ConvertScreen)} />
   </HomeStack.Navigator>
 );
 

--- a/__tests__/TransactionItem.test.tsx
+++ b/__tests__/TransactionItem.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { TransactionItem } from '../components/TransactionItem';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import type { Transaction } from '../services/api';
+
+const renderWithProviders = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('TransactionItem', () => {
+  it('renders inbound BTC transaction with fiat detail', () => {
+    const transaction: Transaction = {
+      id: 'tx-1',
+      currency: 'BTC',
+      primaryAmount: 0.01,
+      amountBtc: 0.01,
+      amountUsd: 200,
+      convertedAmountBtc: null,
+      convertedAmountUsd: null,
+      direction: 'inbound',
+      status: 'confirmed',
+      confirmations: 2,
+      txId: 'hash-1',
+      createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+      description: 'Inbound payment',
+      fee: { amount: 0.0002, currency: 'BTC', usd: 8 },
+      counterparty: 'bc1qtest',
+      usdPerBtc: 20000,
+      sourceCurrency: null,
+      requestedAmount: null,
+    };
+
+    const { getByText } = renderWithProviders(<TransactionItem transaction={transaction} />);
+
+    expect(getByText('+0.01000000 BTC')).toBeTruthy();
+    expect(getByText('+$200.00')).toBeTruthy();
+    expect(getByText('Fee')).toBeTruthy();
+    expect(getByText('Inbound · BTC')).toBeTruthy();
+  });
+
+  it('renders conversion details for USD to BTC', () => {
+    const transaction: Transaction = {
+      id: 'tx-2',
+      currency: 'BTC',
+      primaryAmount: 0.005,
+      amountBtc: 0.005,
+      amountUsd: null,
+      convertedAmountBtc: 0.005,
+      convertedAmountUsd: null,
+      direction: 'inbound',
+      status: 'pending',
+      confirmations: null,
+      txId: null,
+      createdAt: new Date('2024-02-02T00:00:00Z').toISOString(),
+      description: 'USD to BTC conversion',
+      fee: { amount: 5, currency: 'USD', usd: 5 },
+      counterparty: null,
+      usdPerBtc: 40000,
+      sourceCurrency: 'USD',
+      requestedAmount: 250,
+    };
+
+    const { getByText } = renderWithProviders(<TransactionItem transaction={transaction} />);
+
+    expect(getByText('+0.00500000 BTC')).toBeTruthy();
+    expect(getByText('From $250.00')).toBeTruthy();
+    expect(getByText('Convert USD to BTC')).toBeTruthy();
+  });
+});
+

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -60,6 +60,11 @@ const fiat = {
     process.env.EXCHANGE_RATE_CACHE_MS,
     'EXCHANGE_RATE_CACHE_MS',
     60_000
+  ),
+  defaultUsdPerBtc: parseNumberOptional(
+    process.env.DEFAULT_USD_PER_BTC,
+    'DEFAULT_USD_PER_BTC',
+    30_000
   )
 };
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",
+    "pg-mem": "^3.0.5",
     "prettier": "^3.2.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"

--- a/backend/src/controllers/v1/BalanceController.ts
+++ b/backend/src/controllers/v1/BalanceController.ts
@@ -8,8 +8,12 @@ export class BalanceController {
     }
 
     try {
-      const balances = await WalletService.getBalances(req.user.id);
-      return res.status(200).json({ btcBalance: balances.BTC, usdBalance: balances.USD });
+      const snapshot = await WalletService.getBalances(req.user.id);
+      return res.status(200).json({
+        btcBalance: snapshot.balances.BTC,
+        usdBalance: snapshot.balances.USD,
+        rates: { usdPerBtc: snapshot.usdPerBtc },
+      });
     } catch (error) {
       return res.status(500).json({ message: 'Unable to fetch balances', error: (error as Error).message });
     }

--- a/backend/tests/global.d.ts
+++ b/backend/tests/global.d.ts
@@ -1,0 +1,2 @@
+declare module 'pg-mem';
+

--- a/backend/tests/helpers/database.ts
+++ b/backend/tests/helpers/database.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+
+type TestDatabase = {
+  db: unknown;
+  pool: Pool;
+};
+
+const loadPgMem = () => {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    return require('pg-mem') as { newDb: (options?: { autoCreateForeignKeyIndices?: boolean }) => unknown };
+  } catch (error) {
+    throw new Error('pg-mem module is required to run integration tests.');
+  }
+};
+
+const SCHEMA_SQL = [
+  `CREATE TABLE users (
+      id SERIAL PRIMARY KEY,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT now()
+    );`,
+  `CREATE TABLE wallets (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      currency TEXT NOT NULL CHECK (currency IN ('BTC','USD')),
+      balance NUMERIC(30,8) NOT NULL DEFAULT 0,
+      pending_balance NUMERIC(30,8) NOT NULL DEFAULT 0,
+      deposit_address TEXT,
+      created_at TIMESTAMP NOT NULL DEFAULT now(),
+      updated_at TIMESTAMP NOT NULL DEFAULT now()
+    );`,
+  `CREATE UNIQUE INDEX wallets_user_currency_unique ON wallets(user_id, currency);`,
+  `CREATE TABLE transactions (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      type TEXT NOT NULL CHECK (type IN ('deposit','withdrawal','transfer','conversion','fee','rate_adjustment')),
+      direction TEXT NOT NULL CHECK (direction IN ('debit','credit')),
+      status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','confirmed','failed')),
+      currency TEXT NOT NULL CHECK (currency IN ('BTC','USD')),
+      amount NUMERIC(30,8) NOT NULL,
+      fee_amount NUMERIC(30,8) NOT NULL DEFAULT 0,
+      description TEXT,
+      tx_hash TEXT,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMP NOT NULL DEFAULT now(),
+      updated_at TIMESTAMP NOT NULL DEFAULT now()
+    );`,
+  `CREATE INDEX transactions_user_created_idx ON transactions(user_id, created_at);`,
+  `CREATE INDEX transactions_tx_hash_idx ON transactions(tx_hash);`,
+  `CREATE TABLE ledger_entries (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+      wallet_id UUID NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
+      direction TEXT NOT NULL CHECK (direction IN ('debit','credit')),
+      amount NUMERIC(30,8) NOT NULL,
+      currency TEXT NOT NULL CHECK (currency IN ('BTC','USD')),
+      created_at TIMESTAMP NOT NULL DEFAULT now()
+    );`,
+  `CREATE INDEX ledger_entries_wallet_idx ON ledger_entries(wallet_id);`,
+  `CREATE INDEX ledger_entries_transaction_idx ON ledger_entries(transaction_id);`,
+  `CREATE TABLE exchange_rates (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      base_currency TEXT NOT NULL,
+      quote_currency TEXT NOT NULL,
+      raw_rate NUMERIC(30,8) NOT NULL,
+      fee_rate NUMERIC(6,4) NOT NULL,
+      final_rate NUMERIC(30,8) NOT NULL,
+      fetched_at TIMESTAMP NOT NULL DEFAULT now()
+    );`,
+  `CREATE INDEX exchange_rates_lookup_idx ON exchange_rates(base_currency, quote_currency, fetched_at);`
+];
+
+const registerFunctions = (db: any): void => {
+  db.public.registerFunction({
+    name: 'now',
+    returns: 'timestamp',
+    implementation: () => new Date(),
+  });
+
+  db.public.registerFunction({
+    name: 'uuid_generate_v4',
+    returns: 'uuid',
+    implementation: randomUUID,
+  });
+};
+
+export const createInMemoryDatabase = async (): Promise<TestDatabase> => {
+  const { newDb } = loadPgMem();
+  const memDb: any = (newDb as (options?: { autoCreateForeignKeyIndices?: boolean }) => unknown)({
+    autoCreateForeignKeyIndices: true,
+  });
+  registerFunctions(memDb);
+  const adapter = memDb.adapters.createPg();
+
+  const pg = require('pg') as typeof import('pg');
+  pg.Pool = adapter.Pool;
+  pg.Client = adapter.Client;
+
+  const pool = new adapter.Pool();
+
+  for (const statement of SCHEMA_SQL) {
+    // eslint-disable-next-line no-await-in-loop
+    await pool.query(statement);
+  }
+
+  return { db: memDb, pool };
+};
+
+export const resetModuleCache = (): void => {
+  const modulePaths = [
+    '../../src/db',
+    '../../src/db/db',
+    '../../src/services/WalletService',
+    '../../src/services/ConversionService',
+    '../../src/services/BitcoinService',
+    '../../src/repositories/WalletRepository',
+    '../../src/repositories/TransactionRepository',
+    '../../src/repositories/LedgerRepository',
+  ];
+
+  for (const modulePath of modulePaths) {
+    const resolved = require.resolve(modulePath);
+    delete require.cache[resolved];
+  }
+};
+
+export const destroyDatabase = async (pool: Pool): Promise<void> => {
+  await pool.end();
+};
+

--- a/backend/tests/helpers/integration.ts
+++ b/backend/tests/helpers/integration.ts
@@ -1,0 +1,43 @@
+import type { Pool } from 'pg';
+import { createInMemoryDatabase, destroyDatabase, resetModuleCache } from './database';
+
+export interface TestServices {
+  pool: Pool;
+  cleanup: () => Promise<void>;
+  WalletService: typeof import('../../src/services/WalletService').default;
+  WalletRepository: typeof import('../../src/repositories/WalletRepository').default;
+  TransactionRepository: typeof import('../../src/repositories/TransactionRepository').default;
+  LedgerRepository: typeof import('../../src/repositories/LedgerRepository').default;
+  conversionService: typeof import('../../src/services/ConversionService').default;
+  bitcoinService: typeof import('../../src/services/BitcoinService').default;
+}
+
+export const setupIntegrationServices = async (): Promise<TestServices> => {
+  resetModuleCache();
+  const { pool } = await createInMemoryDatabase();
+
+  const [WalletServiceModule, WalletRepositoryModule, TransactionRepositoryModule, LedgerRepositoryModule, conversionServiceModule, bitcoinServiceModule] =
+    await Promise.all([
+      import('../../src/services/WalletService'),
+      import('../../src/repositories/WalletRepository'),
+      import('../../src/repositories/TransactionRepository'),
+      import('../../src/repositories/LedgerRepository'),
+      import('../../src/services/ConversionService'),
+      import('../../src/services/BitcoinService'),
+    ]);
+
+  return {
+    pool,
+    cleanup: async () => {
+      await destroyDatabase(pool);
+      resetModuleCache();
+    },
+    WalletService: WalletServiceModule.default,
+    WalletRepository: WalletRepositoryModule.default,
+    TransactionRepository: TransactionRepositoryModule.default,
+    LedgerRepository: LedgerRepositoryModule.default,
+    conversionService: conversionServiceModule.default,
+    bitcoinService: bitcoinServiceModule.default,
+  };
+};
+

--- a/backend/tests/helpers/seeds.ts
+++ b/backend/tests/helpers/seeds.ts
@@ -1,0 +1,11 @@
+import type { Pool } from 'pg';
+
+export const insertUser = async (pool: Pool, email = 'test@example.com'): Promise<number> => {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO users (email, password_hash) VALUES ($1, $2) RETURNING id`,
+    [email, '$2a$10$testhash']
+  );
+
+  return result.rows[0].id;
+};
+

--- a/backend/tests/integration/wallet.integration.test.ts
+++ b/backend/tests/integration/wallet.integration.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from '../utils/harness';
+import { setupIntegrationServices } from '../helpers/integration';
+import { insertUser } from '../helpers/seeds';
+
+const parseNumeric = (value: string | null | undefined): number => {
+  if (!value) {
+    return 0;
+  }
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const shouldSkip = (error: unknown): boolean => {
+  return error instanceof Error && error.message.includes('pg-mem module is required');
+};
+
+describe('WalletService integration', () => {
+  it('returns balances with BTC and USD snapshots', async () => {
+    let services;
+    try {
+      services = await setupIntegrationServices();
+    } catch (error) {
+      if (shouldSkip(error)) {
+        console.warn('Skipping integration tests: pg-mem unavailable.');
+        return;
+      }
+      throw error;
+    }
+    const { pool, cleanup, WalletService, WalletRepository, conversionService } = services;
+
+    try {
+      conversionService.setManualRate(30000);
+      const userId = await insertUser(pool, 'balance@test.local');
+
+      const btcWallet = await WalletRepository.createWallet(userId, 'BTC');
+      const usdWallet = await WalletRepository.createWallet(userId, 'USD');
+
+      await pool.query(`UPDATE wallets SET balance = '0.5', pending_balance = '0.1' WHERE id = $1`, [btcWallet.id]);
+      await pool.query(`UPDATE wallets SET balance = '2500', pending_balance = '75' WHERE id = $1`, [usdWallet.id]);
+
+      const snapshot = await WalletService.getBalances(userId);
+      expect(snapshot.balances.BTC.balance).toBeCloseTo(0.5, 8);
+      expect(snapshot.balances.BTC.pending).toBeCloseTo(0.1, 8);
+      expect(snapshot.balances.USD.balance).toBeCloseTo(2500, 2);
+      expect(snapshot.balances.USD.pending).toBeCloseTo(75, 2);
+      expect(snapshot.usdPerBtc).toBeCloseTo(30000, 2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('sends BTC and records transaction and ledger entries', async () => {
+    let services;
+    try {
+      services = await setupIntegrationServices();
+    } catch (error) {
+      if (shouldSkip(error)) {
+        console.warn('Skipping integration tests: pg-mem unavailable.');
+        return;
+      }
+      throw error;
+    }
+    const { pool, cleanup, WalletService, WalletRepository, TransactionRepository, conversionService, bitcoinService } = services;
+
+    try {
+      conversionService.setManualRate(20000);
+      bitcoinService.sendToAddress = async () => 'tx-test-1';
+
+      const userId = await insertUser(pool, 'send@test.local');
+      const btcWallet = await WalletRepository.createWallet(userId, 'BTC');
+
+      await pool.query(`UPDATE wallets SET balance = '0.05' WHERE id = $1`, [btcWallet.id]);
+
+      const result = await WalletService.sendBitcoin(userId, 'bc1qdestination', 0.01);
+      expect(result.txId).toBe('tx-test-1');
+
+      const refreshedWallet = await WalletRepository.findByUserAndCurrency(userId, 'BTC');
+      const remaining = parseNumeric(refreshedWallet?.balance);
+      expect(remaining).toBeLessThan(0.05);
+
+      const transactions = await TransactionRepository.list({ userId, limit: 10, offset: 0 });
+      expect(transactions.length).toBe(1);
+      expect(transactions[0].type).toBe('withdrawal');
+      expect(parseNumeric(transactions[0].feeAmount)).toBeGreaterThan(0);
+
+      const ledgerEntries = await pool.query(
+        `SELECT transaction_id, direction, amount::text AS amount FROM ledger_entries`
+      );
+      expect(ledgerEntries.rowCount).toBe(1);
+      expect(ledgerEntries.rows[0].direction).toBe('debit');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('records bitcoin deposits with pending and confirmation flow', async () => {
+    let services;
+    try {
+      services = await setupIntegrationServices();
+    } catch (error) {
+      if (shouldSkip(error)) {
+        console.warn('Skipping integration tests: pg-mem unavailable.');
+        return;
+      }
+      throw error;
+    }
+    const { pool, cleanup, WalletService, WalletRepository, conversionService } = services;
+
+    try {
+      conversionService.setManualRate(25000);
+      const userId = await insertUser(pool, 'deposit@test.local');
+      await WalletRepository.createWallet(userId, 'BTC');
+
+      await WalletService.recordBitcoinDeposit({
+        userId,
+        amountBtc: 0.02,
+        txHash: 'hash-1',
+        confirmations: 0,
+      });
+
+      let btcWallet = await WalletRepository.findByUserAndCurrency(userId, 'BTC');
+      expect(parseNumeric(btcWallet?.pendingBalance)).toBeGreaterThan(0);
+      expect(parseNumeric(btcWallet?.balance)).toBeCloseTo(0, 8);
+
+      await WalletService.recordBitcoinDeposit({
+        userId,
+        amountBtc: 0.02,
+        txHash: 'hash-1',
+        confirmations: 2,
+      });
+
+      btcWallet = await WalletRepository.findByUserAndCurrency(userId, 'BTC');
+      expect(parseNumeric(btcWallet?.pendingBalance)).toBeCloseTo(0, 8);
+      expect(parseNumeric(btcWallet?.balance)).toBeGreaterThan(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('converts balances between USD and BTC', async () => {
+    let services;
+    try {
+      services = await setupIntegrationServices();
+    } catch (error) {
+      if (shouldSkip(error)) {
+        console.warn('Skipping integration tests: pg-mem unavailable.');
+        return;
+      }
+      throw error;
+    }
+    const { pool, cleanup, WalletService, WalletRepository, conversionService } = services;
+
+    try {
+      conversionService.setManualRate(40000);
+      const userId = await insertUser(pool, 'convert@test.local');
+      const btcWallet = await WalletRepository.createWallet(userId, 'BTC');
+      const usdWallet = await WalletRepository.createWallet(userId, 'USD');
+
+      await pool.query(`UPDATE wallets SET balance = '1000' WHERE id = $1`, [usdWallet.id]);
+
+      const usdToBtc = await WalletService.convert(userId, 'USD', 200);
+      expect(usdToBtc.direction).toBe('USD_TO_BTC');
+      expect(usdToBtc.convertedAmount).toBeGreaterThan(0);
+
+      let refreshedUsd = await WalletRepository.findByUserAndCurrency(userId, 'USD');
+      let refreshedBtc = await WalletRepository.findByUserAndCurrency(userId, 'BTC');
+      expect(parseNumeric(refreshedUsd?.balance)).toBeLessThan(1000);
+      expect(parseNumeric(refreshedBtc?.balance)).toBeGreaterThan(0);
+
+      await pool.query(`UPDATE wallets SET balance = '0.05' WHERE id = $1`, [btcWallet.id]);
+
+      const btcToUsd = await WalletService.convert(userId, 'BTC', 0.01);
+      expect(btcToUsd.direction).toBe('BTC_TO_USD');
+      expect(btcToUsd.convertedAmount).toBeGreaterThan(0);
+
+      refreshedUsd = await WalletRepository.findByUserAndCurrency(userId, 'USD');
+      refreshedBtc = await WalletRepository.findByUserAndCurrency(userId, 'BTC');
+      expect(parseNumeric(refreshedUsd?.balance)).toBeGreaterThan(0);
+      expect(parseNumeric(refreshedBtc?.balance)).toBeLessThan(0.05);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+

--- a/backend/tests/run-tests.ts
+++ b/backend/tests/run-tests.ts
@@ -4,6 +4,7 @@ import { run } from './utils/harness';
 import './unit/controllers/AuthController.test';
 import './unit/services/FeeService.test';
 import './unit/middleware/authMiddleware.test';
+import './integration/wallet.integration.test';
 
 (async () => {
   await run();

--- a/components/TransactionItem.tsx
+++ b/components/TransactionItem.tsx
@@ -1,4 +1,3 @@
-
 import React, { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { Card } from './Card';
@@ -30,6 +29,19 @@ const getStatusColor = (status: Transaction['status'], colors: ThemeColors): str
   }
 };
 
+const getStatusBackground = (status: Transaction['status'], colors: ThemeColors): string => {
+  switch (status) {
+    case 'confirmed':
+      return `${colors.success}20`;
+    case 'pending':
+      return `${colors.warning}20`;
+    case 'failed':
+      return `${colors.error}20`;
+    default:
+      return `${colors.border}`;
+  }
+};
+
 const formatDate = (value: string): string => {
   const date = new Date(value);
   return new Intl.DateTimeFormat('en-US', {
@@ -41,13 +53,15 @@ const formatDate = (value: string): string => {
   }).format(date);
 };
 
-const formatUsd = (amount: number): string =>
+const formatUSD = (amount: number): string =>
   new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount);
+
+const formatBTC = (amount: number): string => amount.toFixed(8);
 
 const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
   StyleSheet.create({
@@ -57,19 +71,37 @@ const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
     header: {
       flexDirection: 'row',
       justifyContent: 'space-between',
+      alignItems: 'flex-start',
       marginBottom: 12,
     },
     amount: {
       ...typography.heading,
       fontSize: 22,
     },
-    status: {
-      ...typography.subheading,
-      fontSize: 14,
+    direction: {
+      ...typography.caption,
+      color: colors.textSecondary,
       textTransform: 'uppercase',
+      letterSpacing: 1,
     },
-    meta: {
+    detail: {
+      ...typography.body,
+      color: colors.textSecondary,
       marginTop: 4,
+    },
+    statusBadge: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 999,
+    },
+    statusText: {
+      ...typography.caption,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    metaRow: {
+      marginTop: 10,
     },
     metaLabel: {
       ...typography.caption,
@@ -79,57 +111,139 @@ const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
     metaValue: {
       ...typography.monospace,
       fontSize: 13,
-    },
-    fiatValue: {
-      ...typography.body,
-      color: colors.textSecondary,
-      marginTop: 4,
-    },
-    direction: {
-      ...typography.caption,
-      color: colors.textSecondary,
-      textTransform: 'uppercase',
-      letterSpacing: 1,
+      color: colors.textPrimary,
     },
   });
+
+const formatPrimaryAmount = (transaction: Transaction): string => {
+  const sign = transaction.direction === 'inbound' ? '+' : '-';
+  if (transaction.currency === 'USD') {
+    return `${sign}${formatUSD(transaction.primaryAmount)}`;
+  }
+  return `${sign}${formatBTC(transaction.primaryAmount)} BTC`;
+};
+
+const buildDetailLines = (transaction: Transaction): string[] => {
+  const sign = transaction.direction === 'inbound' ? '+' : '-';
+  const lines: string[] = [];
+
+  if (transaction.currency === 'BTC' && transaction.amountUsd != null) {
+    lines.push(`${sign}${formatUSD(transaction.amountUsd)}`);
+  } else if (transaction.currency === 'USD' && transaction.amountBtc != null) {
+    lines.push(`${sign}${formatBTC(transaction.amountBtc)} BTC`);
+  }
+
+  if (transaction.sourceCurrency && transaction.sourceCurrency !== transaction.currency && transaction.requestedAmount != null) {
+    const formattedSource = transaction.sourceCurrency === 'USD'
+      ? formatUSD(transaction.requestedAmount)
+      : `${formatBTC(transaction.requestedAmount)} BTC`;
+    lines.push(`From ${formattedSource}`);
+  }
+
+  return lines;
+};
+
+const formatFeeDetail = (transaction: Transaction): string | null => {
+  const { fee } = transaction;
+  if (fee.amount == null && fee.usd == null) {
+    return null;
+  }
+
+  if (fee.currency === 'USD') {
+    return formatUSD(fee.amount ?? fee.usd ?? 0);
+  }
+
+  if (fee.currency === 'BTC') {
+    const btcValue = fee.amount ?? 0;
+    const usdValue = fee.usd;
+    return usdValue != null ? `${formatBTC(btcValue)} BTC (${formatUSD(usdValue)})` : `${formatBTC(btcValue)} BTC`;
+  }
+
+  if (fee.usd != null) {
+    return formatUSD(fee.usd);
+  }
+
+  return null;
+};
 
 export const TransactionItem: React.FC<TransactionItemProps> = ({ transaction }) => {
   const { colors } = useTheme();
   const { typography } = useThemedStyles();
   const styles = useMemo(() => createStyles(colors, typography), [colors, typography]);
+
+  const primaryAmount = useMemo(() => formatPrimaryAmount(transaction), [transaction]);
+  const detailLines = useMemo(() => buildDetailLines(transaction), [transaction]);
+  const feeDetail = useMemo(() => formatFeeDetail(transaction), [transaction]);
+
   const statusColor = getStatusColor(transaction.status, colors);
-  const directionSign = transaction.direction === 'inbound' ? '+' : '-';
-  const btcAmount = Math.abs(transaction.amountBtc ?? 0);
-  const amountLabel = `${directionSign}${btcAmount.toFixed(8)} BTC`;
-  const fiatDisplay =
-    transaction.amountUsd != null
-      ? `${directionSign}${formatUsd(Math.abs(transaction.amountUsd))}`
-      : null;
+  const statusBackground = getStatusBackground(transaction.status, colors);
+  const directionLabel = transaction.direction === 'inbound' ? 'Inbound' : 'Outbound';
 
   return (
     <View style={styles.container}>
       <Card>
         <View style={styles.header}>
           <View>
-            <Text style={styles.amount}>{amountLabel}</Text>
-            <Text style={styles.direction}>{transaction.direction === 'inbound' ? 'Inbound' : 'Outbound'}</Text>
-            {fiatDisplay ? <Text style={styles.fiatValue}>{fiatDisplay}</Text> : null}
+            <Text style={styles.amount}>{primaryAmount}</Text>
+            <Text style={styles.direction}>
+              {directionLabel} · {transaction.currency}
+            </Text>
+            {detailLines.map(line => (
+              <Text key={line} style={styles.detail}>
+                {line}
+              </Text>
+            ))}
           </View>
-          <Text style={[styles.status, { color: statusColor }]}>{STATUS_LABEL[transaction.status]}</Text>
+          <View style={[styles.statusBadge, { backgroundColor: statusBackground }]}>
+            <Text style={[styles.statusText, { color: statusColor }]}>{STATUS_LABEL[transaction.status]}</Text>
+          </View>
         </View>
-        <View style={styles.meta}>
+
+        <View style={styles.metaRow}>
           <Text style={styles.metaLabel}>Date</Text>
           <Text style={styles.metaValue}>{formatDate(transaction.createdAt)}</Text>
         </View>
-        <View style={styles.meta}>
-          <Text style={styles.metaLabel}>Transaction ID</Text>
-          <Text style={styles.metaValue} selectable numberOfLines={1} ellipsizeMode="middle">
-            {transaction.txId ?? 'Pending assignment'}
-          </Text>
-        </View>
+
+        {transaction.counterparty ? (
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>Counterparty</Text>
+            <Text style={styles.metaValue}>{transaction.counterparty}</Text>
+          </View>
+        ) : null}
+
+        {feeDetail ? (
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>Fee</Text>
+            <Text style={styles.metaValue}>{feeDetail}</Text>
+          </View>
+        ) : null}
+
+        {transaction.confirmations != null ? (
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>Confirmations</Text>
+            <Text style={styles.metaValue}>{transaction.confirmations}</Text>
+          </View>
+        ) : null}
+
+        {transaction.txId ? (
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>Transaction ID</Text>
+            <Text style={styles.metaValue} numberOfLines={1} ellipsizeMode="middle" selectable>
+              {transaction.txId}
+            </Text>
+          </View>
+        ) : null}
+
+        {transaction.description ? (
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>Notes</Text>
+            <Text style={styles.metaValue}>{transaction.description}</Text>
+          </View>
+        ) : null}
       </Card>
     </View>
   );
 };
 
 export default TransactionItem;
+

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import * as LocalAuthentication from 'expo-local-authentication';
-import { login as loginRequest, setAuthToken, signup as signupRequest } from '../services/api';
+import { clearStoredKeys, login as loginRequest, setAuthToken, signup as signupRequest } from '../services/api';
 import { clearToken, getStoredToken, storeToken } from '../services/auth';
 
 type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
@@ -119,7 +119,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setError(null);
 
     try {
-      await clearToken();
+      await Promise.all([clearToken(), clearStoredKeys()]);
       setAuthToken(null);
       setUserToken(null);
     } catch (logoutError) {

--- a/contexts/BalanceContext.tsx
+++ b/contexts/BalanceContext.tsx
@@ -1,63 +1,203 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { getBalance, sendBTC as sendBTCApi, type SendBTCResponse, type WalletBalance } from '../services/api';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  getBalance,
+  getTransactions,
+  sendBTC as sendBTCApi,
+  type BalanceSummary,
+  type SendBTCResponse,
+  type Transaction,
+  type WalletSnapshot,
+} from '../services/api';
+import { useAuth } from './AuthContext';
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+type RefreshOptions = { silent?: boolean };
+
+interface WalletBalancesState {
+  btc: BalanceSummary;
+  usd: BalanceSummary;
+}
+
+interface WalletRatesState {
+  usdPerBtc: number;
+}
 
 export interface BalanceContextValue {
-  balance: number;
-  fiatBalance: number;
-  fiatCurrency: string | null;
-  pendingBalance: number;
-  pendingFiatBalance: number;
-  refreshBalance: () => Promise<void>;
+  balances: WalletBalancesState;
+  rates: WalletRatesState;
+  transactions: Transaction[];
+  balancesReady: boolean;
+  transactionsReady: boolean;
+  refreshBalances: (options?: RefreshOptions) => Promise<void>;
+  refreshTransactions: (options?: RefreshOptions) => Promise<void>;
   sendBTC: (address: string, amount: number) => Promise<SendBTCResponse>;
 }
 
+const EMPTY_BALANCE: BalanceSummary = {
+  balance: 0,
+  pending: 0,
+  depositAddress: null,
+};
+
 const BalanceContext = createContext<BalanceContextValue | undefined>(undefined);
 
-export const BalanceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [balance, setBalance] = useState<number>(0);
-  const [fiatBalance, setFiatBalance] = useState<number>(0);
-  const [fiatCurrency, setFiatCurrency] = useState<string | null>(null);
-  const [pendingBalance, setPendingBalance] = useState<number>(0);
-  const [pendingFiatBalance, setPendingFiatBalance] = useState<number>(0);
-  const applyBalance = useCallback((walletBalance: WalletBalance) => {
-    setBalance(walletBalance.btcBalance.balance);
-    setPendingBalance(walletBalance.btcBalance.pending);
-    setFiatBalance(walletBalance.usdBalance.balance);
-    setPendingFiatBalance(walletBalance.usdBalance.pending);
-    setFiatCurrency('USD');
-  }, []);
+const cloneBalance = (balance: BalanceSummary): BalanceSummary => ({
+  balance: balance.balance,
+  pending: balance.pending,
+  depositAddress: balance.depositAddress,
+});
 
-  const refreshBalance = useCallback(async () => {
-    const data = await getBalance();
-    applyBalance(data);
-  }, [applyBalance]);
+const buildInitialBalances = (): WalletBalancesState => ({
+  btc: cloneBalance(EMPTY_BALANCE),
+  usd: cloneBalance(EMPTY_BALANCE),
+});
+
+export const BalanceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { status } = useAuth();
+  const [balances, setBalances] = useState<WalletBalancesState>(buildInitialBalances);
+  const [rates, setRates] = useState<WalletRatesState>({ usdPerBtc: 0 });
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [balancesReady, setBalancesReady] = useState(false);
+  const [transactionsReady, setTransactionsReady] = useState(false);
+  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    refreshBalance().catch(error => {
-      console.error('Failed to refresh balance:', error);
+    return () => {
+      mountedRef.current = false;
+      if (refreshTimerRef.current) {
+        clearInterval(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const applySnapshot = useCallback((snapshot: WalletSnapshot) => {
+    if (!mountedRef.current) {
+      return;
+    }
+
+    setBalances({
+      btc: cloneBalance(snapshot.balances.btc),
+      usd: cloneBalance(snapshot.balances.usd),
     });
-  }, [refreshBalance]);
+    setRates({ usdPerBtc: snapshot.rates.usdPerBtc });
+    setBalancesReady(true);
+  }, []);
+
+  const refreshBalances = useCallback(async ({ silent = false }: RefreshOptions = {}) => {
+    try {
+      const snapshot = await getBalance();
+      applySnapshot(snapshot);
+    } catch (error) {
+      if (silent) {
+        return;
+      }
+
+      console.error('Failed to refresh balances:', error);
+      throw error instanceof Error ? error : new Error('Unable to refresh balances.');
+    }
+  }, [applySnapshot]);
+
+  const refreshTransactions = useCallback(async ({ silent = false }: RefreshOptions = {}) => {
+    try {
+      const data = await getTransactions();
+      if (!mountedRef.current) {
+        return;
+      }
+      setTransactions(data);
+      setTransactionsReady(true);
+    } catch (error) {
+      if (silent) {
+        return;
+      }
+
+      console.error('Failed to refresh transactions:', error);
+      throw error instanceof Error ? error : new Error('Unable to refresh transactions.');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      if (refreshTimerRef.current) {
+        clearInterval(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+
+      setBalances(buildInitialBalances());
+      setRates({ usdPerBtc: 0 });
+      setTransactions([]);
+      setBalancesReady(false);
+      setTransactionsReady(false);
+      return;
+    }
+
+    void Promise.all([
+      refreshBalances(),
+      refreshTransactions(),
+    ]).catch(error => {
+      console.error('Failed to initialise wallet data:', error);
+    });
+
+    if (refreshTimerRef.current) {
+      clearInterval(refreshTimerRef.current);
+    }
+
+    refreshTimerRef.current = setInterval(() => {
+      void refreshBalances({ silent: true });
+      void refreshTransactions({ silent: true });
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      if (refreshTimerRef.current) {
+        clearInterval(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
+  }, [status, refreshBalances, refreshTransactions]);
 
   const sendBTC = useCallback(
     async (address: string, amount: number) => {
       const result = await sendBTCApi(address, amount);
-      await refreshBalance();
+      await Promise.all([
+        refreshBalances({ silent: true }),
+        refreshTransactions({ silent: true }),
+      ]);
       return result;
     },
-    [refreshBalance]
+    [refreshBalances, refreshTransactions]
   );
 
   const value = useMemo(
     () => ({
-      balance,
-      fiatBalance,
-      fiatCurrency,
-      pendingBalance,
-      pendingFiatBalance,
-      refreshBalance,
+      balances,
+      rates,
+      transactions,
+      balancesReady,
+      transactionsReady,
+      refreshBalances,
+      refreshTransactions,
       sendBTC,
     }),
-    [balance, fiatBalance, fiatCurrency, pendingBalance, pendingFiatBalance, refreshBalance, sendBTC]
+    [
+      balances,
+      rates,
+      transactions,
+      balancesReady,
+      transactionsReady,
+      refreshBalances,
+      refreshTransactions,
+      sendBTC,
+    ]
   );
 
   return <BalanceContext.Provider value={value}>{children}</BalanceContext.Provider>;
@@ -70,3 +210,4 @@ export const useBalance = (): BalanceContextValue => {
   }
   return context;
 };
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,8 +84,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: frontend/Dockerfile
     environment:
       EXPO_PUBLIC_API_BASE_URL: http://api:3000
       EXPO_PUBLIC_BITCOIN_RPC_URL: http://bitcoin:18332

--- a/screens/ConvertScreen.tsx
+++ b/screens/ConvertScreen.tsx
@@ -1,0 +1,405 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Button } from '../components/Button';
+import { Card } from '../components/Card';
+import { Input } from '../components/Input';
+import { useBalance } from '../contexts/BalanceContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { useThemedStyles, TypographyStyles } from '../theme/styles';
+import type { ThemeColors } from '../theme/colors';
+import {
+  executeConversion,
+  getConversionQuote,
+  type ConversionQuote,
+} from '../services/api';
+import { HomeStackParamList } from '../types/navigation';
+
+const formatUSD = (amount: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+const formatBTC = (amount: number): string => amount.toFixed(8);
+
+const showToast = (message: string) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('HASH', message);
+  }
+};
+
+const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
+  StyleSheet.create({
+    safeArea: {
+      paddingTop: 32,
+    },
+    contentContainer: {
+      flexGrow: 1,
+      paddingBottom: 48,
+    },
+    header: {
+      marginBottom: 24,
+    },
+    title: {
+      ...typography.heading,
+      marginBottom: 8,
+    },
+    subtitle: {
+      ...typography.body,
+      color: colors.textSecondary,
+    },
+    toggleGroup: {
+      flexDirection: 'row',
+      borderRadius: 14,
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.border,
+      overflow: 'hidden',
+      marginBottom: 24,
+    },
+    toggleOption: {
+      flex: 1,
+      paddingVertical: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'transparent',
+    },
+    toggleOptionActive: {
+      backgroundColor: colors.accent,
+    },
+    toggleLabel: {
+      ...typography.subheading,
+      color: colors.textSecondary,
+    },
+    toggleLabelActive: {
+      color: colors.background,
+    },
+    formSection: {
+      marginBottom: 24,
+    },
+    field: {
+      marginBottom: 16,
+    },
+    summaryCard: {
+      marginBottom: 24,
+    },
+    summaryRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: 12,
+    },
+    summaryLabel: {
+      ...typography.body,
+      color: colors.textSecondary,
+    },
+    summaryValue: {
+      ...typography.body,
+      fontWeight: '600',
+    },
+    summaryTotal: {
+      ...typography.subheading,
+      fontWeight: '700',
+    },
+    helperText: {
+      ...typography.caption,
+      color: colors.textSecondary,
+    },
+    errorText: {
+      ...typography.caption,
+      color: colors.error,
+      marginTop: 8,
+    },
+    rateText: {
+      ...typography.caption,
+      color: colors.textSecondary,
+      marginTop: 12,
+    },
+    buttonWrapper: {
+      marginTop: 24,
+    },
+  });
+
+const sanitizeAmount = (value: string, decimals: number): string => {
+  const trimmed = value.replace(/[^0-9.]/g, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  const [whole, ...decimalParts] = trimmed.split('.');
+  const decimal = decimalParts.join('').slice(0, decimals);
+  return decimalParts.length > 0 ? `${whole}.${decimal}` : whole;
+};
+
+const ConvertScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+  const { refreshBalances, refreshTransactions, rates } = useBalance();
+  const { colors } = useTheme();
+  const { layout, typography } = useThemedStyles();
+  const styles = useMemo(() => createStyles(colors, typography), [colors, typography]);
+
+  const [fromCurrency, setFromCurrency] = useState<'USD' | 'BTC'>('USD');
+  const [amount, setAmount] = useState('');
+  const [quote, setQuote] = useState<ConversionQuote | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const targetCurrency = fromCurrency === 'USD' ? 'BTC' : 'USD';
+
+  const amountValue = useMemo(() => {
+    const parsed = Number.parseFloat(amount);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [amount]);
+
+  const handleChangeCurrency = useCallback(
+    (next: 'USD' | 'BTC') => {
+      if (next === fromCurrency) {
+        return;
+      }
+      setFromCurrency(next);
+      setAmount('');
+      setQuote(null);
+      setQuoteError(null);
+      setQuoteLoading(false);
+    },
+    [fromCurrency]
+  );
+
+  const handleAmountChange = useCallback(
+    (value: string) => {
+      const decimals = fromCurrency === 'USD' ? 2 : 8;
+      setAmount(sanitizeAmount(value, decimals));
+    },
+    [fromCurrency]
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
+    if (!amount) {
+      setQuote(null);
+      setQuoteError(null);
+      setQuoteLoading(false);
+      return;
+    }
+
+    const parsed = Number.parseFloat(amount);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setQuote(null);
+      setQuoteError(null);
+      setQuoteLoading(false);
+      return;
+    }
+
+    setQuoteLoading(true);
+    setQuoteError(null);
+
+    let cancelled = false;
+
+    debounceRef.current = setTimeout(() => {
+      getConversionQuote(fromCurrency, parsed)
+        .then(result => {
+          if (!cancelled) {
+            setQuote(result);
+          }
+        })
+        .catch(error => {
+          if (!cancelled) {
+            setQuote(null);
+            const message = error instanceof Error ? error.message : 'Unable to fetch conversion quote.';
+            setQuoteError(message);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setQuoteLoading(false);
+          }
+        });
+    }, 350);
+
+    return () => {
+      cancelled = true;
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [amount, fromCurrency]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!quote || amountValue <= 0) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await executeConversion(fromCurrency, amountValue);
+      showToast('Conversion completed');
+      setAmount('');
+      setQuote(null);
+      setQuoteError(null);
+      await Promise.all([
+        refreshBalances({ silent: true }),
+        refreshTransactions({ silent: true }),
+      ]);
+      navigation.goBack();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to process conversion.';
+      showToast(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [amountValue, fromCurrency, navigation, quote, refreshBalances, refreshTransactions]);
+
+  const feeAmountNumber = useMemo(() => {
+    if (!quote) {
+      return 0;
+    }
+    const parsed = Number.parseFloat(quote.feeAmount);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [quote]);
+
+  const conversionRateText = useMemo(() => {
+    if (!quote) {
+      return rates.usdPerBtc > 0
+        ? `Market rate: ${formatUSD(rates.usdPerBtc)} per BTC`
+        : 'Awaiting conversion quote…';
+    }
+    return `Quote locked at ${formatUSD(quote.rate.raw)} per BTC`;
+  }, [quote, rates.usdPerBtc]);
+
+  const feeDisplay = useMemo(() => {
+    if (!quote) {
+      return null;
+    }
+
+    if (fromCurrency === 'USD') {
+      const impliedBtc = quote.rate.raw > 0 ? quote.feeUsd / quote.rate.raw : 0;
+      return `${formatUSD(feeAmountNumber)} (${formatBTC(impliedBtc)} BTC)`;
+    }
+
+    return `${formatBTC(feeAmountNumber)} BTC (${formatUSD(quote.feeUsd)})`;
+  }, [feeAmountNumber, fromCurrency, quote]);
+
+  const receiveDisplay = useMemo(() => {
+    if (!quote) {
+      return null;
+    }
+
+    return targetCurrency === 'USD' ? formatUSD(quote.convertedAmount) : `${formatBTC(quote.convertedAmount)} BTC`;
+  }, [quote, targetCurrency]);
+
+  const sendDisplay = useMemo(() => {
+    if (!quote) {
+      return null;
+    }
+
+    return fromCurrency === 'USD' ? formatUSD(quote.requestedAmount) : `${formatBTC(quote.requestedAmount)} BTC`;
+  }, [fromCurrency, quote]);
+
+  const effectiveRate = useMemo(() => {
+    if (!quote) {
+      return rates.usdPerBtc > 0 ? `Market rate: ${formatUSD(rates.usdPerBtc)}` : 'Rate unavailable';
+    }
+    return `Effective rate: ${formatUSD(quote.rate.final)} per BTC`;
+  }, [quote, rates.usdPerBtc]);
+
+  const isSubmitDisabled = amountValue <= 0 || !quote || quoteLoading || isSubmitting || Boolean(quoteError);
+
+  return (
+    <SafeAreaView style={[layout.screen, styles.safeArea]}>
+      <KeyboardAvoidingView
+        style={layout.screen}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 24 : 0}
+      >
+        <ScrollView contentContainerStyle={[styles.contentContainer]} keyboardShouldPersistTaps="handled">
+          <View style={styles.header}>
+            <Text style={styles.title}>Convert Funds</Text>
+            <Text style={styles.subtitle}>Move between USD and BTC instantly with transparent fees.</Text>
+          </View>
+
+          <View style={styles.toggleGroup}>
+            <Pressable
+              style={[styles.toggleOption, fromCurrency === 'USD' && styles.toggleOptionActive]}
+              onPress={() => handleChangeCurrency('USD')}
+            >
+              <Text style={[styles.toggleLabel, fromCurrency === 'USD' && styles.toggleLabelActive]}>USD → BTC</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.toggleOption, fromCurrency === 'BTC' && styles.toggleOptionActive]}
+              onPress={() => handleChangeCurrency('BTC')}
+            >
+              <Text style={[styles.toggleLabel, fromCurrency === 'BTC' && styles.toggleLabelActive]}>BTC → USD</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.formSection}>
+            <Input
+              label={`Amount (${fromCurrency})`}
+              placeholder={fromCurrency === 'USD' ? '0.00' : '0.00000000'}
+              value={amount}
+              onChangeText={handleAmountChange}
+              keyboardType="decimal-pad"
+              containerStyle={styles.field}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <Text style={styles.helperText}>{conversionRateText}</Text>
+            {quoteError ? <Text style={styles.errorText}>{quoteError}</Text> : null}
+          </View>
+
+          <Card style={styles.summaryCard}>
+            <View style={styles.summaryRow}>
+              <Text style={styles.summaryLabel}>You Send</Text>
+              <Text style={styles.summaryValue}>{sendDisplay ?? '—'}</Text>
+            </View>
+            <View style={styles.summaryRow}>
+              <Text style={styles.summaryLabel}>Conversion Fee</Text>
+              <Text style={styles.summaryValue}>{feeDisplay ?? '—'}</Text>
+            </View>
+            <View style={styles.summaryRow}>
+              <Text style={styles.summaryLabel}>You Receive</Text>
+              <Text style={styles.summaryTotal}>{receiveDisplay ?? '—'}</Text>
+            </View>
+            <Text style={styles.rateText}>{effectiveRate}</Text>
+          </Card>
+
+          <View style={styles.buttonWrapper}>
+            <Button
+              label={quoteLoading ? 'Fetching quote…' : isSubmitting ? 'Converting…' : 'Convert Now'}
+              onPress={handleSubmit}
+              disabled={isSubmitDisabled}
+              loading={isSubmitting}
+              fullWidth
+            />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+export default ConvertScreen;
+

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import Animated, { FadeIn } from 'react-native-reanimated';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Button } from '../components/Button';
+import { Card } from '../components/Card';
 import { useBalance } from '../contexts/BalanceContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useThemedStyles, TypographyStyles } from '../theme/styles';
@@ -13,18 +14,13 @@ import { HomeStackParamList } from '../types/navigation';
 
 const formatBTC = (amount: number): string => amount.toFixed(8);
 
-const formatFiat = (amount: number, currency: string | null): string => {
-  if (currency) {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount);
-  }
-
-  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-};
+const formatUSD = (amount: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
 
 const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
   StyleSheet.create({
@@ -39,21 +35,49 @@ const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
     balanceContainer: {
       marginTop: 24,
     },
-    balanceLabel: {
+    totalLabel: {
       ...typography.subheading,
       textTransform: 'uppercase',
       letterSpacing: 1,
-      marginBottom: 12,
+      marginBottom: 8,
     },
-    balanceValue: {
-      fontSize: 48,
+    totalValue: {
+      fontSize: 40,
       fontWeight: '800',
       color: colors.textPrimary,
     },
-    balanceFiat: {
+    totalSecondary: {
       ...typography.body,
       color: colors.textSecondary,
-      marginTop: 8,
+      marginTop: 6,
+    },
+    balancesGrid: {
+      marginTop: 24,
+      flexDirection: 'row',
+      gap: 16,
+    },
+    balanceCard: {
+      flex: 1,
+    },
+    cardTitle: {
+      ...typography.subheading,
+      marginBottom: 12,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    cardAmount: {
+      ...typography.heading,
+      fontSize: 24,
+    },
+    cardSecondary: {
+      ...typography.body,
+      color: colors.textSecondary,
+      marginTop: 4,
+    },
+    rateText: {
+      ...typography.caption,
+      color: colors.textSecondary,
+      marginTop: 12,
     },
     actionsContainer: {
       marginTop: 48,
@@ -68,7 +92,7 @@ const createStyles = (colors: ThemeColors, typography: TypographyStyles) =>
   });
 
 const HomeScreen: React.FC = () => {
-  const { balance, fiatBalance, fiatCurrency, pendingBalance, pendingFiatBalance, refreshBalance } = useBalance();
+  const { balances, rates, refreshBalances, balancesReady } = useBalance();
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
   const [refreshing, setRefreshing] = useState(false);
   const { colors } = useTheme();
@@ -77,20 +101,20 @@ const HomeScreen: React.FC = () => {
 
   useFocusEffect(
     useCallback(() => {
-      refreshBalance().catch(error => {
+      refreshBalances().catch(error => {
         console.error('Failed to refresh wallet balance:', error);
       });
-    }, [refreshBalance])
+    }, [refreshBalances])
   );
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await refreshBalance();
+      await refreshBalances();
     } finally {
       setRefreshing(false);
     }
-  }, [refreshBalance]);
+  }, [refreshBalances]);
 
   const handleNavigateToSend = useCallback(() => {
     navigation.navigate('Send');
@@ -100,17 +124,26 @@ const HomeScreen: React.FC = () => {
     navigation.navigate('Receive');
   }, [navigation]);
 
-  const formattedBTC = useMemo(() => formatBTC(balance), [balance]);
-  const formattedFiat = useMemo(() => formatFiat(fiatBalance, fiatCurrency), [fiatBalance, fiatCurrency]);
-  const formattedPendingBtc = useMemo(() => formatBTC(pendingBalance), [pendingBalance]);
-  const formattedPendingFiat = useMemo(
-    () => formatFiat(pendingFiatBalance, fiatCurrency),
-    [pendingFiatBalance, fiatCurrency]
+  const handleNavigateToConvert = useCallback(() => {
+    navigation.navigate('Convert');
+  }, [navigation]);
+
+  const btcBalance = balances.btc.balance;
+  const btcPending = balances.btc.pending;
+  const usdBalance = balances.usd.balance;
+  const usdPending = balances.usd.pending;
+
+  const totalUsdValue = useMemo(
+    () => usdBalance + btcBalance * rates.usdPerBtc,
+    [btcBalance, rates.usdPerBtc, usdBalance]
   );
-  const hasPending = useMemo(
-    () => Math.abs(pendingBalance) > 0 || Math.abs(pendingFiatBalance) > 0,
-    [pendingBalance, pendingFiatBalance]
-  );
+
+  const totalBtcValue = useMemo(() => {
+    if (rates.usdPerBtc <= 0) {
+      return btcBalance;
+    }
+    return btcBalance + usdBalance / rates.usdPerBtc;
+  }, [btcBalance, rates.usdPerBtc, usdBalance]);
 
   return (
     <SafeAreaView style={[layout.screen, styles.safeArea]}>
@@ -119,19 +152,35 @@ const HomeScreen: React.FC = () => {
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.accent} />}
       >
         <Animated.View entering={FadeIn.duration(600)} style={styles.balanceContainer}>
-          <Text style={styles.balanceLabel}>Total Balance</Text>
-          <Text style={styles.balanceValue}>{formattedBTC} BTC</Text>
-          <Text style={styles.balanceFiat}>{formattedFiat}</Text>
-          {hasPending ? (
-            <Text style={styles.balanceFiat}>
-              Pending: {formattedPendingBtc} BTC · {formattedPendingFiat}
-            </Text>
-          ) : null}
+          <Text style={styles.totalLabel}>Total Wallet Value</Text>
+          <Text style={styles.totalValue}>{formatUSD(totalUsdValue)}</Text>
+          <Text style={styles.totalSecondary}>{formatBTC(totalBtcValue)} BTC</Text>
+          <Text style={styles.rateText}>
+            {balancesReady && rates.usdPerBtc > 0 ? `1 BTC ≈ ${formatUSD(rates.usdPerBtc)}` : 'Updating market rate…'}
+          </Text>
         </Animated.View>
+
+        <View style={styles.balancesGrid}>
+          <Card style={styles.balanceCard}>
+            <Text style={styles.cardTitle}>Bitcoin</Text>
+            <Text style={styles.cardAmount}>{formatBTC(btcBalance)} BTC</Text>
+            <Text style={styles.cardSecondary}>Pending: {formatBTC(btcPending)} BTC</Text>
+            <Text style={styles.cardSecondary}>{formatUSD(btcBalance * rates.usdPerBtc)}</Text>
+          </Card>
+          <Card style={styles.balanceCard}>
+            <Text style={styles.cardTitle}>US Dollar</Text>
+            <Text style={styles.cardAmount}>{formatUSD(usdBalance)}</Text>
+            <Text style={styles.cardSecondary}>Pending: {formatUSD(usdPending)}</Text>
+            <Text style={styles.cardSecondary}>
+              ≈ {rates.usdPerBtc > 0 ? formatBTC(usdBalance / rates.usdPerBtc) : '—'} BTC
+            </Text>
+          </Card>
+        </View>
 
         <View style={styles.actionsContainer}>
           <Button label="Send" onPress={handleNavigateToSend} fullWidth style={[styles.actionButton, styles.firstAction]} />
           <Button label="Receive" onPress={handleNavigateToReceive} fullWidth style={styles.actionButton} />
+          <Button label="Convert" onPress={handleNavigateToConvert} fullWidth style={styles.actionButton} />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -20,4 +20,5 @@ export type HomeStackParamList = {
   HomeMain: undefined;
   Send: undefined;
   Receive: undefined;
+  Convert: undefined;
 };


### PR DESCRIPTION
## Summary
- add a dual-currency balance provider that refreshes balances and history on an interval and clears state on logout
- implement send, convert, home, and history updates including fee summaries, conversion workflows, and richer transaction cards
- extend the API client and backend services for conversion flows, transaction metadata, integration tests, and docker stack improvements

## Testing
- npm test (backend)


------
https://chatgpt.com/codex/tasks/task_e_68e18585a53c832fadaabcc11ec4f4b3